### PR TITLE
Use middleware to validate user info

### DIFF
--- a/pkg/errs/errs.go
+++ b/pkg/errs/errs.go
@@ -225,6 +225,11 @@ func E(args ...interface{}) error {
 	if len(args) == 0 {
 		panic("call to errors.E with no arguments")
 	}
+
+	if len(args) == 1 && args[0] == nil {
+		return nil
+	}
+
 	e := &Error{}
 	for _, arg := range args {
 		switch arg := arg.(type) {

--- a/pkg/service/core/handlers/handler_workstations.go
+++ b/pkg/service/core/handlers/handler_workstations.go
@@ -36,18 +36,8 @@ func (h *WorkstationsHandler) EnsureWorkstation(ctx context.Context, r *http.Req
 
 func (h *WorkstationsHandler) GetWorkstation(ctx context.Context, _ *http.Request, _ any) (*service.WorkstationOutput, error) {
 	const op errs.Op = "WorkstationsHandler.GetWorkstation"
-
-	user := auth.GetUser(ctx)
-	if user == nil {
-		return nil, errs.E(errs.Unauthenticated, op, errs.Str("no user in context"))
-	}
-
-	workstation, err := h.service.GetWorkstation(ctx, user)
-	if err != nil {
-		return nil, errs.E(op, err)
-	}
-
-	return workstation, nil
+	workstation, err := h.service.GetWorkstation(ctx, auth.GetUser(ctx))
+	return workstation, errs.E(op, err)
 }
 
 func (h *WorkstationsHandler) DeleteWorkstation(ctx context.Context, _ *http.Request, _ any) (*transport.Empty, error) {

--- a/pkg/service/core/routes/routes_workstations.go
+++ b/pkg/service/core/routes/routes_workstations.go
@@ -31,6 +31,10 @@ func NewWorkstationsEndpoints(log zerolog.Logger, h *handlers.WorkstationsHandle
 
 func NewWorkstationsRoutes(endpoints *WorkstationsEndpoints, auth func(http.Handler) http.Handler) AddRoutesFn {
 	return func(router chi.Router) {
+		router.With(auth).With(transport.UserInfo()).Route("/api/test/workstations", func(r chi.Router) {
+			r.Get("/", endpoints.GetWorkstation)
+		})
+
 		router.With(auth).Route("/api/workstations", func(r chi.Router) {
 			r.Post("/", endpoints.EnsureWorkstation)
 			r.Get("/", endpoints.GetWorkstation)

--- a/pkg/service/core/transport/middleware.go
+++ b/pkg/service/core/transport/middleware.go
@@ -1,0 +1,46 @@
+package transport
+
+import (
+	"net/http"
+
+	"github.com/navikt/nada-backend/pkg/auth"
+	"github.com/navikt/nada-backend/pkg/service"
+)
+
+type MiddlewareHandler func(http.Handler) http.Handler
+
+func UserInfo(withinAnyGroup ...string) MiddlewareHandler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user := auth.GetUser(r.Context())
+			if user == nil {
+				http.Error(w, `{"error": "No user in context"}`, http.StatusUnauthorized)
+				return
+			}
+
+			if len(withinAnyGroup) == 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			for _, group := range withinAnyGroup {
+				if containsGroup(user.GoogleGroups, group) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			http.Error(w, `{"error": "User not in authorized group"}`, http.StatusUnauthorized)
+		})
+	}
+}
+
+func containsGroup(groups service.Groups, groupEmail string) bool {
+	for _, g := range groups {
+		if g.Email == groupEmail {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
I see a lot of code about validating the user info in context and in group. I think it could be put in a middleware. Also I think errs.E() should accept nil input so we do not need to say
if err!= nil{
 ...
}

in many places.

If you do not like the change just reject the PR, it is just my preference and suggestion