### PR TITLE
Make alias for iam.ServiceAccount

### DIFF
--- a/pkg/sa/sa.go
+++ b/pkg/sa/sa.go
@@ -73,14 +73,7 @@ func (s ServiceAccountRequest) Validate() error {
 	)
 }
 
-type ServiceAccount struct {
-	Description string
-	DisplayName string
-	Email       string
-	Name        string
-	ProjectId   string
-	UniqueId    string
-}
+type ServiceAccount = iam.ServiceAccount
 
 var _ Operations = &Client{}
 
@@ -330,19 +323,7 @@ func (c *Client) ListServiceAccounts(ctx context.Context, project string) ([]*Se
 		return nil, fmt.Errorf("listing service accounts: %w", err)
 	}
 
-	accounts := make([]*ServiceAccount, len(raw.Accounts))
-	for i, account := range raw.Accounts {
-		accounts[i] = &ServiceAccount{
-			Description: account.Description,
-			DisplayName: account.DisplayName,
-			Email:       account.Email,
-			Name:        account.Name,
-			ProjectId:   account.ProjectId,
-			UniqueId:    account.UniqueId,
-		}
-	}
-
-	return accounts, nil
+	return raw.Accounts, nil
 }
 
 func (c *Client) DeleteServiceAccount(ctx context.Context, name string) error {
@@ -380,14 +361,7 @@ func (c *Client) GetServiceAccount(ctx context.Context, name string) (*ServiceAc
 		return nil, fmt.Errorf("getting service account: %w", err)
 	}
 
-	return &ServiceAccount{
-		Description: account.Description,
-		DisplayName: account.DisplayName,
-		Email:       account.Email,
-		Name:        account.Name,
-		ProjectId:   account.ProjectId,
-		UniqueId:    account.UniqueId,
-	}, nil
+	return account, nil
 }
 
 func (c *Client) CreateServiceAccount(ctx context.Context, sa *ServiceAccountRequest) (*ServiceAccount, error) {
@@ -413,14 +387,7 @@ func (c *Client) CreateServiceAccount(ctx context.Context, sa *ServiceAccountReq
 		return nil, fmt.Errorf("creating service account: %w", err)
 	}
 
-	return &ServiceAccount{
-		Description: account.Description,
-		DisplayName: account.DisplayName,
-		Email:       account.Email,
-		Name:        account.Name,
-		ProjectId:   account.ProjectId,
-		UniqueId:    account.UniqueId,
-	}, nil
+	return account, nil
 }
 
 func (c *Client) iamService(ctx context.Context) (*iam.Service, error) {

--- a/pkg/service/core/api/gcp/gcp_service_account.go
+++ b/pkg/service/core/api/gcp/gcp_service_account.go
@@ -28,14 +28,7 @@ func (a *serviceAccountAPI) ListServiceAccounts(ctx context.Context, gcpProject 
 
 	for _, r := range raw {
 		account := &service.ServiceAccount{
-			ServiceAccountMeta: &service.ServiceAccountMeta{
-				Description: r.Description,
-				DisplayName: r.DisplayName,
-				Email:       r.Email,
-				Name:        r.Name,
-				ProjectId:   r.ProjectId,
-				UniqueId:    r.UniqueId,
-			},
+			ServiceAccountMeta: r,
 		}
 
 		keys, err := a.ops.ListServiceAccountKeys(ctx, r.Name)
@@ -202,14 +195,7 @@ func (a *serviceAccountAPI) ensureServiceAccountExists(ctx context.Context, req 
 
 	account, err := a.ops.GetServiceAccount(ctx, sa.ServiceAccountNameFromAccountID(req.ProjectID, req.AccountID))
 	if err == nil {
-		return &service.ServiceAccountMeta{
-			Description: account.Description,
-			DisplayName: account.DisplayName,
-			Email:       account.Email,
-			Name:        account.Name,
-			ProjectId:   account.ProjectId,
-			UniqueId:    account.UniqueId,
-		}, nil
+		return account, nil
 	}
 
 	if !errors.Is(err, sa.ErrNotFound) {
@@ -228,14 +214,7 @@ func (a *serviceAccountAPI) ensureServiceAccountExists(ctx context.Context, req 
 		return nil, errs.E(errs.IO, op, fmt.Errorf("creating service account '%s': %w", sa.ServiceAccountNameFromAccountID(req.ProjectID, req.AccountID), err))
 	}
 
-	return &service.ServiceAccountMeta{
-		Description: account.Description,
-		DisplayName: account.DisplayName,
-		Email:       account.Email,
-		Name:        account.Name,
-		ProjectId:   account.ProjectId,
-		UniqueId:    account.UniqueId,
-	}, nil
+	return account, nil
 }
 
 func NewServiceAccountAPI(ops sa.Operations) *serviceAccountAPI {

--- a/pkg/service/serviceaccount.go
+++ b/pkg/service/serviceaccount.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/navikt/nada-backend/pkg/sa"
 )
 
 type ServiceAccountAPI interface {
@@ -71,14 +72,7 @@ func (s ServiceAccountRequestWithBinding) Validate() error {
 	)
 }
 
-type ServiceAccountMeta struct {
-	Description string
-	DisplayName string
-	Email       string
-	Name        string
-	ProjectId   string
-	UniqueId    string
-}
+type ServiceAccountMeta = sa.ServiceAccount
 
 type ServiceAccount struct {
 	*ServiceAccountMeta


### PR DESCRIPTION
it seems iam.ServiceAccount is wrapped twice without adding information, I think it could be simplified with alias