### PR TITLE
Umami

### DIFF
--- a/.nais/dev/nada-backend/gcp.yaml
+++ b/.nais/dev/nada-backend/gcp.yaml
@@ -37,8 +37,8 @@ spec:
     path: /internal/metrics
   ingresses:
     - "https://data.ansatt.dev.nav.no/api"
-    - "https://data.ansatt.dev.nav.no/story"
     - "https://data.ansatt.dev.nav.no/quarto"
+    - "https://data.ansatt.dev.nav.no/quarto/fetch"
     - "https://nada.intern.dev.nav.no/quarto/create"
     - "https://nada.intern.dev.nav.no/quarto/update"
     - "https://nada.intern.dev.nav.no/api/story"

--- a/.nais/prod/nada-backend/gcp.yaml
+++ b/.nais/prod/nada-backend/gcp.yaml
@@ -36,10 +36,10 @@ spec:
     path: /internal/metrics
   ingresses:
     - "https://data.ansatt.nav.no/api"
-    - "https://data.ansatt.nav.no/story"
-    - "https://data.ansatt.nav.no/quarto"
+    - "https://data.ansatt.dev.nav.no/quarto"
+    - "https://data.ansatt.nav.no/quarto/fetch"
     - "https://nada.intern.nav.no/quarto/update"
-    - "https://nada.intern.nav.no/api/story"
+    - "https://nada.intern.nav.no/api/story/fetch"
     - "https://datamarkedsplassen.intern.nav.no/quarto/create"
     - "https://datamarkedsplassen.intern.nav.no/quarto/update"
     - "https://datamarkedsplassen.intern.nav.no/api/story"

--- a/frontend/global.d.ts
+++ b/frontend/global.d.ts
@@ -1,0 +1,10 @@
+// global.d.ts
+export {};
+
+declare global {
+  interface Window {
+    umami: {
+      track: (eventName: string, eventData?: string | object) => void;
+    };
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -11,6 +11,7 @@ import PageLayout from '../components/pageLayout'
 import { useFetchUserData } from '../lib/rest/userData'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { UserState } from '../lib/context'
+import Script from 'next/script'
 
 const UserInfo = ({ Component, pageProps }: AppProps) => {
   const userData = useFetchUserData()
@@ -41,6 +42,7 @@ const UserInfo = ({ Component, pageProps }: AppProps) => {
       <meta name="theme-color" content="#ffffff" />
       <title>nav data</title>
     </Head>
+    <Script defer src="https://cdn.nav.no/team-researchops/sporing/sporing.js" data-host-url="https://umami.nav.no" data-website-id="0f5ab812-053c-4776-8ef1-0ea3778b8936" />
     <PageLayout>
       <Component {...pageProps} />
     </PageLayout>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -34,8 +34,8 @@ const LandingPage = () => {
         <div className="w-screen min-h-[calc(100vh-6rem)] flex flex-col gap-8 bg-gray-100">
             <Head>
                 <title>datamarkedsplassen</title>
-                <Script defer src="https://cdn.nav.no/team-researchops/sporing/sporing.js" data-host-url="https://umami.nav.no" data-website-id="0f5ab812-053c-4776-8ef1-0ea3778b8936" />
             </Head>
+            <Script defer src="https://cdn.nav.no/team-researchops/sporing/sporing.js" data-host-url="https://umami.nav.no" data-website-id="0f5ab812-053c-4776-8ef1-0ea3778b8936" />
             <AccessRequestAlert></AccessRequestAlert>
             <div className="bg-surface-subtle p-8 min-h-[34rem] items-center justify-center flex flex-col md:flex-row gap-8">
                 <ProductAreaLinks/>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -14,6 +14,7 @@ import GetStartedIcon from "../components/lib/icons/getStartedIcon";
 import { Next } from '@navikt/ds-icons'
 import DatadrivenIcon from "../components/lib/icons/datadrivenIcon";
 import { AccessRequestAlert } from '../components/user/accessRequestAlert'
+import Script from 'next/script'
 
 const SEARCH_LIMIT = 6
 
@@ -33,6 +34,7 @@ const LandingPage = () => {
         <div className="w-screen min-h-[calc(100vh-6rem)] flex flex-col gap-8 bg-gray-100">
             <Head>
                 <title>datamarkedsplassen</title>
+                <Script defer src="https://cdn.nav.no/team-researchops/sporing/sporing.js" data-host-url="https://umami.nav.no" data-website-id="0f5ab812-053c-4776-8ef1-0ea3778b8936" />
             </Head>
             <AccessRequestAlert></AccessRequestAlert>
             <div className="bg-surface-subtle p-8 min-h-[34rem] items-center justify-center flex flex-col md:flex-row gap-8">
@@ -81,6 +83,7 @@ const LandingPage = () => {
                 <FrontPageLogo />
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full md:w-[32rem]">
                     <form
+                        data-umami-event="Frontpage search"
                         className="col-span-1 md:col-span-2 select-none"
                         role="search" 
                         onSubmit={e =>{

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,4 +1,3 @@
-import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import { FrontPageLogo } from '../components/index/frontPageLogo'
 import { useEffect, useState } from 'react'
@@ -8,13 +7,12 @@ import StoryLogo from '../components/lib/icons/storyLogo'
 import Link from 'next/link'
 import ProductAreaLinks from '../components/productArea/productAreaLinks'
 import DataproductLogo from '../components/lib/icons/dataproductLogo'
-import {Heading, Search} from '@navikt/ds-react'
-import LegalGuidanceIcon from "../components/lib/icons/legalGuidanceIcon";
-import GetStartedIcon from "../components/lib/icons/getStartedIcon";
+import { Heading, Search } from '@navikt/ds-react'
+import LegalGuidanceIcon from "../components/lib/icons/legalGuidanceIcon"
+import GetStartedIcon from "../components/lib/icons/getStartedIcon"
 import { Next } from '@navikt/ds-icons'
-import DatadrivenIcon from "../components/lib/icons/datadrivenIcon";
+import DatadrivenIcon from "../components/lib/icons/datadrivenIcon"
 import { AccessRequestAlert } from '../components/user/accessRequestAlert'
-import Script from 'next/script'
 
 const SEARCH_LIMIT = 6
 
@@ -35,7 +33,6 @@ const LandingPage = () => {
             <Head>
                 <title>datamarkedsplassen</title>
             </Head>
-            <Script defer src="https://cdn.nav.no/team-researchops/sporing/sporing.js" data-host-url="https://umami.nav.no" data-website-id="0f5ab812-053c-4776-8ef1-0ea3778b8936" />
             <AccessRequestAlert></AccessRequestAlert>
             <div className="bg-surface-subtle p-8 min-h-[34rem] items-center justify-center flex flex-col md:flex-row gap-8">
                 <ProductAreaLinks/>

--- a/frontend/pages/story/[id]/[[...page]].tsx
+++ b/frontend/pages/story/[id]/[[...page]].tsx
@@ -4,9 +4,11 @@ import { useEffect } from "react"
 //the page proxy for umami analytics
 const StoryProxy = ()=>{
     const router = useRouter()
-    console.log(router.query)
 
     useEffect(()=>{
+        if (typeof window !== 'undefined' && window.umami) {
+            window.umami.track('view-story', router.query.id)
+          }        
         if(router.query.id){
             router.push(`/quarto/${router.query.id}`)
         }

--- a/frontend/pages/story/[id]/[[...page]].tsx
+++ b/frontend/pages/story/[id]/[[...page]].tsx
@@ -7,7 +7,7 @@ const StoryProxy = ()=>{
 
     useEffect(()=>{
         if (typeof window !== 'undefined' && window.umami) {
-            window.umami.track('view-story', router.query.id)
+            window.umami.track('view-story', {id: router.query.id})
           }        
         if(router.query.id){
             router.push(`/quarto/${router.query.id}`)

--- a/frontend/pages/story/[id]/[[...page]].tsx
+++ b/frontend/pages/story/[id]/[[...page]].tsx
@@ -1,0 +1,19 @@
+import { useRouter } from "next/router"
+import { useEffect } from "react"
+
+//the page proxy for umami analytics
+const StoryProxy = ()=>{
+    const router = useRouter()
+    console.log(router.query)
+
+    useEffect(()=>{
+        if(router.query.id){
+            router.push(`/quarto/${router.query.id}`)
+        }
+    })
+    return <>
+        <p>Omdirigere...</p>
+    </>;
+}
+
+export default StoryProxy

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,6 +15,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "global.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "stories"]
 }

--- a/pkg/service/core/routes/routes_story.go
+++ b/pkg/service/core/routes/routes_story.go
@@ -41,7 +41,7 @@ func NewStoryRoutes(
 	nadaToken func(http.Handler) http.Handler,
 ) AddRoutesFn {
 	return func(router chi.Router) {
-		router.Route(`/{story|quarto}`, func(r chi.Router) {
+		router.Route(`/quarto`, func(r chi.Router) {
 			r.Get("/{id}", endpoints.GetIndex)
 			r.Get("/{id}/*", endpoints.GetObject)
 

--- a/test/integration/story_test.go
+++ b/test/integration/story_test.go
@@ -217,7 +217,7 @@ func TestStory(t *testing.T) {
 
 	t.Run("Get index", func(t *testing.T) {
 		data := NewTester(t, server).
-			Get(ctx, "/story/"+story.ID.String()).
+			Get(ctx, "/quarto/"+story.ID.String()).
 			HasStatusCode(http.StatusOK).
 			Body()
 
@@ -264,7 +264,7 @@ func TestStory(t *testing.T) {
 
 	t.Run("Get index - ensure correct top level index html is returned for story", func(t *testing.T) {
 		data := NewTester(t, server).
-			Get(ctx, "/story/"+story.ID.String()).
+			Get(ctx, "/quarto/"+story.ID.String()).
 			HasStatusCode(http.StatusOK).
 			Body()
 
@@ -290,7 +290,7 @@ func TestStory(t *testing.T) {
 
 	t.Run("Create story without token", func(t *testing.T) {
 		NewTester(t, server).
-			Post(ctx, &service.NewStory{}, "/story/create").
+			Post(ctx, &service.NewStory{}, "/quarto/create").
 			HasStatusCode(http.StatusUnauthorized)
 	})
 
@@ -319,7 +319,7 @@ func TestStory(t *testing.T) {
 
 		NewTester(t, server).
 			Headers(map[string]string{"Authorization": fmt.Sprintf("Bearer %s", token)}).
-			Post(ctx, newStory, "/story/create").
+			Post(ctx, newStory, "/quarto/create").
 			HasStatusCode(http.StatusOK).
 			Expect(expect, story, cmpopts.IgnoreFields(service.Story{}, "ID", "Created", "LastModified"))
 	})
@@ -335,7 +335,7 @@ func TestStory(t *testing.T) {
 			ctx,
 			t,
 			http.MethodPut,
-			server.URL+"/story/update/"+story.ID.String(),
+			server.URL+"/quarto/update/"+story.ID.String(),
 			files,
 			nil,
 			map[string]string{
@@ -349,7 +349,7 @@ func TestStory(t *testing.T) {
 
 		for path, content := range files {
 			got := NewTester(t, server).
-				Get(ctx, "/story/"+story.ID.String()+"/"+path).
+				Get(ctx, "/quarto/"+story.ID.String()+"/"+path).
 				HasStatusCode(http.StatusOK).
 				Body()
 
@@ -366,7 +366,7 @@ func TestStory(t *testing.T) {
 			ctx,
 			t,
 			http.MethodPatch,
-			server.URL+"/story/update/"+story.ID.String(),
+			server.URL+"/quarto/update/"+story.ID.String(),
 			files,
 			nil,
 			map[string]string{
@@ -379,7 +379,7 @@ func TestStory(t *testing.T) {
 			HasStatusCode(http.StatusNoContent)
 
 		got := NewTester(t, server).
-			Get(ctx, "/story/"+story.ID.String()+"/newpage/test.html").
+			Get(ctx, "/quarto/"+story.ID.String()+"/newpage/test.html").
 			HasStatusCode(http.StatusOK).
 			Body()
 


### PR DESCRIPTION
Problem:
nada-backend mounts on /story/* and /quarto/* paths, which makes the frontend not able to track user event on these paths.

Solution:
1. nada-backend only serves /quarto/* paths, while nada-frontend serves GET /story/{id}
2. when user browse /story/{id}, the frontend redirect to /quarto/{id} and send the track event

Consequences:
1. the url for fetch story is not changed, so user's bookmark still works
2. the urls
 /quarto/create
 /quarto/update
 still work
 3. the urls
 /story/create
 /story/update
 no longer work, but I have searched github and did not find code use these urls. also the path was not included in the nada-backend ingress
 4. if user use GET /story/{id} programmatically, the behavior of markedsplassen changed, and user will receive a frontend page instead of the actual story