### PR TITLE
fix: http proxy envs are set as part of the dockerimage startup scrip…

### DIFF
--- a/pkg/service/workstations.go
+++ b/pkg/service/workstations.go
@@ -51,9 +51,6 @@ const (
 	// WorkstationConfigIDLabel is a label applied to the running workstation by GCP
 	WorkstationConfigIDLabel = "workstation_config_id"
 
-	DefaultWorkstationProxyURL    = "http://proxy.knada.local:443"
-	DefaultWorkstationNoProxyList = ".adeo.no,.preprod.local,.test.local,.intern.nav.no,.intern.dev.nav.no,.nais.adeo.no,localhost,metadata.google.internal,169.254.169.254"
-
 	SecureWebProxyCertFile = "/usr/local/share/ca-certificates/swp.crt"
 
 	// WorkstationEffectiveTagGCPKeyParentName is the key for the parent name in the effective tag set by Google themselves
@@ -712,15 +709,6 @@ func DefaultWorkstationEnv(ident, email, fullName string) map[string]string {
 		"WORKSTATION_NAME":           ident,
 		"WORKSTATION_USER_EMAIL":     email,
 		"WORKSTATION_USER_FULL_NAME": fullName,
-
-		"http_proxy": DefaultWorkstationProxyURL,
-		"HTTP_PROXY": DefaultWorkstationProxyURL,
-
-		"https_proxy": DefaultWorkstationProxyURL,
-		"HTTPS_PROXY": DefaultWorkstationProxyURL,
-
-		"no_proxy": DefaultWorkstationNoProxyList,
-		"NO_PROXY": DefaultWorkstationNoProxyList,
 
 		"NODE_EXTRA_CA_CERTS": SecureWebProxyCertFile,
 

--- a/pkg/workstations/emulator/emulator.go
+++ b/pkg/workstations/emulator/emulator.go
@@ -320,6 +320,8 @@ func (e *Emulator) updateWorkstationConfig(w http.ResponseWriter, r *http.Reques
 			storedReq.Annotations = req.Annotations
 		case "readinessChecks":
 			storedReq.ReadinessChecks = req.ReadinessChecks
+		case "container.env":
+			storedReq.GetContainer().Env = req.GetContainer().Env
 		}
 	}
 

--- a/pkg/workstations/workstations.go
+++ b/pkg/workstations/workstations.go
@@ -729,6 +729,7 @@ func (c *Client) UpdateWorkstationConfig(ctx context.Context, opts *WorkstationC
 			},
 			Container: &workstationspb.WorkstationConfig_Container{
 				Image: opts.ContainerImage,
+				Env:   opts.Env,
 			},
 		},
 		UpdateMask: &fieldmaskpb.FieldMask{
@@ -737,6 +738,7 @@ func (c *Client) UpdateWorkstationConfig(ctx context.Context, opts *WorkstationC
 				"container.image",
 				"annotations",
 				"readiness_checks",
+				"container.env",
 			},
 		},
 		ValidateOnly: false,

--- a/pkg/workstations/workstations_test.go
+++ b/pkg/workstations/workstations_test.go
@@ -46,6 +46,7 @@ func TestWorkstationOperations(t *testing.T) {
 		Annotations:        map[string]string{"onprem-allow-list": "host1,host2"},
 		MachineType:        service.MachineTypeN2DStandard2,
 		ServiceAccount:     saEmail,
+		Env:                map[string]string{"WORKSTATION_HOST": workstationHost},
 		Image:              workstations.ContainerImageVSCode,
 		IdleTimeout:        workstations.DefaultIdleTimeoutInSec * time.Second,
 		RunningTimeout:     workstations.DefaultRunningTimeoutInSec * time.Second,
@@ -80,6 +81,7 @@ func TestWorkstationOperations(t *testing.T) {
 			Annotations:         map[string]string{"onprem-allow-list": "host1,host2"},
 			MachineType:         service.MachineTypeN2DStandard2,
 			ServiceAccountEmail: saEmail,
+			Env:                 map[string]string{"WORKSTATION_HOST": workstationHost},
 			SubjectEmail:        "nada@nav.no",
 			ContainerImage:      workstations.ContainerImageVSCode,
 		})
@@ -124,12 +126,14 @@ func TestWorkstationOperations(t *testing.T) {
 				Port: 80,
 			},
 		}
+		workstationConfig.Env = map[string]string{"WORKSTATION_HOST": workstationHost, "WORKSTATION_PORT": "80"}
 
 		got, err := client.UpdateWorkstationConfig(ctx, &workstations.WorkstationConfigUpdateOpts{
 			Slug:           configSlug,
 			Annotations:    map[string]string{"onprem-allow-list": "host1,host2,host3"},
 			MachineType:    service.MachineTypeN2DStandard32,
 			ContainerImage: workstations.ContainerImagePosit,
+			Env:            map[string]string{"WORKSTATION_HOST": workstationHost, "WORKSTATION_PORT": "80"},
 			ReadinessChecks: []*workstations.ReadinessCheck{
 				{
 					Path: "/healthcheck",
@@ -162,6 +166,8 @@ func TestWorkstationOperations(t *testing.T) {
 				Port: 80,
 			},
 		}
+		workstationConfig.Env = map[string]string{"WORKSTATION_HOST": workstationHost, "WORKSTATION_PORT": "80"}
+
 		require.NoError(t, err)
 		diff := cmp.Diff(workstationConfig, got, cmpopts.IgnoreFields(workstations.WorkstationConfig{}, "CreateTime", "UpdateTime", "CompleteConfigAsJSON"))
 		assert.Empty(t, diff)

--- a/test/integration/workstations_test.go
+++ b/test/integration/workstations_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/billing/apiv1/billingpb"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/navikt/nada-backend/pkg/cloudbilling"
 	"github.com/navikt/nada-backend/pkg/datavarehus"
 	"github.com/navikt/nada-backend/pkg/iamcredentials"
@@ -457,6 +458,7 @@ func TestWorkstations(t *testing.T) {
 				Image:          service.ContainerImageVSCode,
 				IdleTimeout:    2 * time.Hour,
 				RunningTimeout: 12 * time.Hour,
+				Env:            service.DefaultWorkstationEnv("v101010", "user.userson@email.com", "User Userson"),
 				ReadinessChecks: []*service.ReadinessCheck{
 					{
 						Path: "/healthcheck",
@@ -471,7 +473,10 @@ func TestWorkstations(t *testing.T) {
 		NewTester(t, server).
 			Get(ctx, "/api/workstations/").
 			HasStatusCode(gohttp.StatusOK).
-			Expect(expectedWorkstation, workstation, cmpopts.IgnoreFields(service.WorkstationOutput{}, "CreateTime", "Config.UpdateTime", "StartTime", "Config.CreateTime", "Config.Env"))
+			Expect(expectedWorkstation, workstation, cmpopts.IgnoreFields(service.WorkstationOutput{}, "CreateTime", "Config.UpdateTime", "StartTime", "Config.CreateTime"))
+
+		fmt.Println("Workstation created:")
+		spew.Dump(workstation)
 
 		assert.Truef(t, maps.Equal(workstation.Config.Env, service.DefaultWorkstationEnv(slug, UserOne.Email, UserOneName)), "Expected %v, got %v", map[string]string{"WORKSTATION_NAME": slug}, workstation.Config.Env)
 	})
@@ -492,6 +497,7 @@ func TestWorkstations(t *testing.T) {
 				RunningTimeout: 12 * time.Hour,
 				MachineType:    service.MachineTypeN2DStandard16,
 				Image:          service.ContainerImageVSCode,
+				Env:            service.DefaultWorkstationEnv("v101010", "user.userson@email.com", "User Userson"),
 				ReadinessChecks: []*service.ReadinessCheck{
 					{
 						Path: "/healthcheck",
@@ -505,7 +511,7 @@ func TestWorkstations(t *testing.T) {
 		NewTester(t, server).
 			Get(ctx, "/api/workstations/").Debug(os.Stdout).
 			HasStatusCode(gohttp.StatusOK).
-			Expect(expected, workstation, cmpopts.IgnoreFields(service.WorkstationOutput{}, "CreateTime", "StartTime", "Config.CreateTime", "Config.UpdateTime", "Config.Env"))
+			Expect(expected, workstation, cmpopts.IgnoreFields(service.WorkstationOutput{}, "CreateTime", "StartTime", "Config.CreateTime", "Config.UpdateTime"))
 		assert.NotNil(t, workstation.StartTime)
 	})
 
@@ -590,6 +596,7 @@ func TestWorkstations(t *testing.T) {
 				RunningTimeout: 12 * time.Hour,
 				MachineType:    service.MachineTypeN2DStandard32,
 				Image:          service.ContainerImageIntellijUltimate,
+				Env:            service.DefaultWorkstationEnv("v101010", "user.userson@email.com", "User Userson"),
 				ReadinessChecks: []*service.ReadinessCheck{
 					{
 						Path: "/healthcheck",
@@ -603,7 +610,7 @@ func TestWorkstations(t *testing.T) {
 		NewTester(t, server).
 			Get(ctx, "/api/workstations/").Debug(os.Stdout).
 			HasStatusCode(gohttp.StatusOK).
-			Expect(expected, workstation, cmpopts.IgnoreFields(service.WorkstationOutput{}, "CreateTime", "StartTime", "UpdateTime", "Config.CreateTime", "Config.UpdateTime", "Config.Env"))
+			Expect(expected, workstation, cmpopts.IgnoreFields(service.WorkstationOutput{}, "CreateTime", "StartTime", "UpdateTime", "Config.CreateTime", "Config.UpdateTime"))
 		assert.NotNil(t, workstation.StartTime)
 		assert.Truef(t, maps.Equal(workstation.Config.Env, service.DefaultWorkstationEnv(slug, UserOne.Email, UserOne.Name)), "Expected %v, got %v", map[string]string{"WORKSTATION_NAME": slug}, workstation.Config.Env)
 	})


### PR DESCRIPTION
…ts and no longer needs to be included in the workstation config. Also included container.env as part of the update mask when updating workstation configs.