### PR TITLE
chore(metabase): Increase memory request in dev from 1024Mi to 1536Mi

### DIFF
--- a/.nais/dev/metabase/gcp.yaml
+++ b/.nais/dev/metabase/gcp.yaml
@@ -75,7 +75,7 @@ spec:
       memory: 2048Mi
     requests:
       cpu: 20m
-      memory: 1024Mi
+      memory: 1536Mi
   accessPolicy:
     inbound:
       rules:


### PR DESCRIPTION
It seems requests defines the actual limit because of JAVA_OPTS: --XX:MaxRAMPercentage=75.0