### PR TITLE
fix(tests): use IPv4 for pubsubtests

### DIFF
--- a/pkg/pubsub/pubsub_test.go
+++ b/pkg/pubsub/pubsub_test.go
@@ -25,7 +25,9 @@ func TestPubSub(t *testing.T) {
 
 	cfg := c.RunPubSub(integration.NewPubSubConfig())
 
-	client := pubsub.New(cfg.Location, cfg.ClientConnectionURL(), true)
+	os.Setenv("PUBSUB_EMULATOR_HOST", cfg.HostPort)
+
+	client := pubsub.New(cfg.Location, "", true)
 
 	topicName := "topic"
 


### PR DESCRIPTION
Explicitly set envvar PUBSUB_EMULATOR_HOST to use IPv4 in order to work on all machines