### PR TITLE
Delete Metabase database when deleting dataproduct or dataset

### DIFF
--- a/frontend/components/dataproducts/dataproductOwnerMenu.tsx
+++ b/frontend/components/dataproducts/dataproductOwnerMenu.tsx
@@ -20,12 +20,16 @@ const DataproductOwnerMenu = ({
     const [deleteError, setDeleteError] = useState('')
     const router = useRouter()
 
+    const [deleteLoading, setDeleteLoading] = useState(false)
+
     const onDelete = async () => {
         if (!dataproduct) return
+        setDeleteLoading(true)
         deleteDataproduct(dataproduct.id).then(() => {
             router.push('/')
         }).catch(error => {
             setDeleteError(error)
+            setDeleteLoading(false)
         })
     }
 
@@ -41,6 +45,7 @@ const DataproductOwnerMenu = ({
         setShowDeleteEmpty(false)
         setShowDeleteNonEmpty(false)
         setConfirmDeleteNonEmpty(false)
+        setDeleteLoading(false)
     }
 
     return (
@@ -92,7 +97,7 @@ const DataproductOwnerMenu = ({
                         <Button variant="secondary" onClick={closeDeleteModal}>
                             Avbryt
                         </Button>
-                        <Button onClick={onDelete} disabled={!confirmDeleteNonEmpty}>Slett</Button>
+                        <Button onClick={onDelete} disabled={!confirmDeleteNonEmpty || deleteLoading} loading={deleteLoading}>Slett</Button>
                     </div>
                     {deleteError && <Alert variant={'error'}>{deleteError}</Alert>}
                 </Modal.Body>

--- a/frontend/components/dataproducts/dataproductOwnerMenu.tsx
+++ b/frontend/components/dataproducts/dataproductOwnerMenu.tsx
@@ -82,8 +82,11 @@ const DataproductOwnerMenu = ({
                             <li key={dataset.id}><strong>{dataset.name}</strong></li>
                         ))}
                     </ul>
+                    <Alert variant="warning">
+                        Hvis datasettene er tilgjengelig i Metabase vil også de tilhørende databasene bli slettet derfra, inkludert eventuelle spørsmål med disse som kilde.
+                    </Alert>
                     <Checkbox className='mt-2' checked={confirmDeleteNonEmpty} onClick={()=> setConfirmDeleteNonEmpty(!confirmDeleteNonEmpty)}>
-                        Jeg forstår at operasjonen vil slette dataproduktet samt datasettene ovenfor, og at dette ikke kan angres.
+                        Jeg forstår at operasjonen vil slette dataproduktet, datasettene ovenfor og eventuelle Metabase-databaser, og at dette ikke kan angres.
                     </Checkbox>
                     <div className="flex flex-row gap-3">
                         <Button variant="secondary" onClick={closeDeleteModal}>

--- a/frontend/components/dataproducts/dataset/datasetOwnerMenu.tsx
+++ b/frontend/components/dataproducts/dataset/datasetOwnerMenu.tsx
@@ -82,6 +82,8 @@ const DatasetOwnerMenu = ({
         open={showDelete}
         onCancel={() => setShowDelete(false)}
         onConfirm={onDelete}
+        warning={dataset?.metabaseDataset ? "Datasettet er tilgjengelig i Metabase. Databasen vil også bli slettet derfra, inkludert tilganger og eventuelle spørsmål som bruker denne som kilde." : undefined}
+        confirmText={dataset?.metabaseDataset ? "Jeg forstår at datasettet og Metabase-databasen vil bli slettet, og at dette ikke kan angres." : undefined}
       ></DeleteModal>
       <MoveModal
         open={showMove}

--- a/frontend/components/lib/deleteModal.tsx
+++ b/frontend/components/lib/deleteModal.tsx
@@ -24,14 +24,17 @@ export const DeleteModal = ({
 }: DeleteModalProps) => {
 	const action = resource === "metabase-dashboard" ? "Fjern public lenke" : "Slett"
 	const [confirmed, setConfirmed] = useState(false)
+	const [loading, setLoading] = useState(false)
 
 	const handleCancel = () => {
 		setConfirmed(false)
+		setLoading(false)
 		onCancel()
 	}
 
 	const handleConfirm = () => {
 		setConfirmed(false)
+		setLoading(true)
 		onConfirm()
 	}
 
@@ -49,7 +52,7 @@ export const DeleteModal = ({
 					<Button variant="secondary" onClick={handleCancel}>
 						Avbryt
 					</Button>
-					<Button onClick={handleConfirm} disabled={!!confirmText && !confirmed}>{action}</Button>
+					<Button onClick={handleConfirm} disabled={!!confirmText && !confirmed} loading={loading}>{action}</Button>
 				</div>
 				{error && <Alert variant={'error'}>{error}</Alert>}
 			</Modal.Body>

--- a/frontend/components/lib/deleteModal.tsx
+++ b/frontend/components/lib/deleteModal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import { Modal, Button, Alert, BodyShort } from '@navikt/ds-react'
+import { useState } from 'react'
+import { Modal, Button, Alert, BodyShort, Checkbox } from '@navikt/ds-react'
 
 interface DeleteModalProps {
 	open: boolean
@@ -8,6 +9,8 @@ interface DeleteModalProps {
 	name: string
 	error: string
 	resource: string
+	warning?: string
+	confirmText?: string
 }
 export const DeleteModal = ({
 	open,
@@ -16,17 +19,37 @@ export const DeleteModal = ({
 	name,
 	error,
 	resource,
+	warning,
+	confirmText,
 }: DeleteModalProps) => {
 	const action = resource === "metabase-dashboard" ? "Fjern public lenke" : "Slett"
+	const [confirmed, setConfirmed] = useState(false)
+
+	const handleCancel = () => {
+		setConfirmed(false)
+		onCancel()
+	}
+
+	const handleConfirm = () => {
+		setConfirmed(false)
+		onConfirm()
+	}
+
 	return (
-		<Modal open={open} onClose={onCancel} header={{ heading: action }}>
+		<Modal open={open} onClose={handleCancel} header={{ heading: action }}>
 			<Modal.Body className="flex flex-col gap-4">
 				<ConfirmText name={name} resource={resource} />
+				{warning && <Alert variant="warning">{warning}</Alert>}
+				{confirmText && (
+					<Checkbox checked={confirmed} onClick={() => setConfirmed(!confirmed)}>
+						{confirmText}
+					</Checkbox>
+				)}
 				<div className="flex flex-row gap-3">
-					<Button variant="secondary" onClick={onCancel}>
+					<Button variant="secondary" onClick={handleCancel}>
 						Avbryt
 					</Button>
-					<Button onClick={onConfirm}>{action}</Button>
+					<Button onClick={handleConfirm} disabled={!!confirmText && !confirmed}>{action}</Button>
 				</div>
 				{error && <Alert variant={'error'}>{error}</Alert>}
 			</Modal.Body>

--- a/pkg/service/core/service_dataproducts.go
+++ b/pkg/service/core/service_dataproducts.go
@@ -17,6 +17,7 @@ type dataProductsService struct {
 	bigQueryStorage    service.BigQueryStorage
 	bigQueryAPI        service.BigQueryAPI
 	naisConsoleStorage service.NaisConsoleStorage
+	metabaseService    service.MetabaseService
 	allUsersGroup      string
 }
 
@@ -125,6 +126,12 @@ func (s *dataProductsService) DeleteDataproduct(ctx context.Context, user *servi
 
 	if err := ensureUserInGroup(user, dp.Owner.Group); err != nil {
 		return nil, errs.E(op, err)
+	}
+
+	for _, ds := range dp.Datasets {
+		if err := s.metabaseService.DeleteDatabase(ctx, ds.ID); err != nil {
+			return nil, errs.E(op, err)
+		}
 	}
 
 	err = s.dataProductStorage.DeleteDataproduct(ctx, id)
@@ -286,6 +293,10 @@ func (s *dataProductsService) DeleteDataset(ctx context.Context, user *service.U
 		return "", errs.E(op, err)
 	}
 
+	if err := s.metabaseService.DeleteDatabase(ctx, id); err != nil {
+		return "", errs.E(op, err)
+	}
+
 	err = s.dataProductStorage.DeleteDataset(ctx, id)
 	if err != nil {
 		return "", errs.E(op, err)
@@ -378,6 +389,7 @@ func NewDataProductsService(
 	bigQueryStorage service.BigQueryStorage,
 	bigQueryAPI service.BigQueryAPI,
 	naisConsoleStorage service.NaisConsoleStorage,
+	metabaseService service.MetabaseService,
 	allUsersGroup string,
 ) *dataProductsService {
 	return &dataProductsService{
@@ -385,6 +397,7 @@ func NewDataProductsService(
 		bigQueryStorage:    bigQueryStorage,
 		bigQueryAPI:        bigQueryAPI,
 		naisConsoleStorage: naisConsoleStorage,
+		metabaseService:    metabaseService,
 		allUsersGroup:      allUsersGroup,
 	}
 }

--- a/pkg/service/core/services.go
+++ b/pkg/service/core/services.go
@@ -45,14 +45,6 @@ func NewServices(
 		return nil, err
 	}
 
-	dataproductService := NewDataProductsService(
-		stores.DataProductsStorage,
-		stores.BigQueryStorage,
-		clients.BigQueryAPI,
-		stores.NaisConsoleStorage,
-		cfg.AllUsersGroup,
-	)
-
 	metabaseService := NewMetabaseService(
 		cfg.Metabase.GCPProject,
 		cfg.Metabase.KMS.Location,
@@ -74,6 +66,15 @@ func NewServices(
 		stores.DataProductsStorage,
 		stores.AccessStorage,
 		log.With().Str("service", "metabase").Logger(),
+	)
+
+	dataproductService := NewDataProductsService(
+		stores.DataProductsStorage,
+		stores.BigQueryStorage,
+		clients.BigQueryAPI,
+		stores.NaisConsoleStorage,
+		metabaseService,
+		cfg.AllUsersGroup,
 	)
 
 	return &Services{

--- a/test/integration/access_test.go
+++ b/test/integration/access_test.go
@@ -191,6 +191,7 @@ func TestAccess(t *testing.T) {
 		stores.BigQueryStorage,
 		bqapi,
 		stores.NaisConsoleStorage,
+		mbService,
 		GroupEmailAllUsers,
 	)
 

--- a/test/integration/dataproducts_test.go
+++ b/test/integration/dataproducts_test.go
@@ -90,6 +90,7 @@ func TestDataproduct(t *testing.T) {
 		stores.BigQueryStorage,
 		bqapi,
 		stores.NaisConsoleStorage,
+		nil,
 		GroupEmailAllUsers,
 	)
 

--- a/test/integration/metabase/datasource_cleaner_test.go
+++ b/test/integration/metabase/datasource_cleaner_test.go
@@ -161,6 +161,7 @@ func TestBigQueryDatasourceCleaner(t *testing.T) {
 		stores.BigQueryStorage,
 		bqapi,
 		stores.NaisConsoleStorage,
+		mbService,
 		integration.GroupEmailAllUsers,
 	)
 

--- a/test/integration/metabase/metabase_test.go
+++ b/test/integration/metabase/metabase_test.go
@@ -168,6 +168,7 @@ func TestMetabaseOpenDataset(t *testing.T) {
 		stores.BigQueryStorage,
 		bqapi,
 		stores.NaisConsoleStorage,
+		mbService,
 		integration.GroupEmailAllUsers,
 	)
 
@@ -660,6 +661,7 @@ func TestMetabaseOpenRestrictedDataset(t *testing.T) {
 		stores.BigQueryStorage,
 		bqapi,
 		stores.NaisConsoleStorage,
+		mbService,
 		integration.GroupEmailAllUsers,
 	)
 
@@ -945,6 +947,7 @@ func TestMetabaseRestrictedDataset(t *testing.T) {
 		stores.BigQueryStorage,
 		bqapi,
 		stores.NaisConsoleStorage,
+		mbService,
 		integration.GroupEmailAllUsers,
 	)
 


### PR DESCRIPTION
Changes services DeleteDataset and DeleteDataproduct to call metabaseService.DeleteDatabase.
Also creates better warnings in the corresponding delete modals frontend.

This is to avoid creating new orphaned databases in Metabase.