### PR TITLE
 fix(metabase): refresh Metabase integration UI without page reload

### DIFF
--- a/frontend/components/dataproducts/metabaseBigquery.tsx
+++ b/frontend/components/dataproducts/metabaseBigquery.tsx
@@ -49,9 +49,9 @@ const MetabaseBigQueryIntegration: React.FC<MetabaseBigQueryLinkProps> = (
   const restrictedDatasetStatus = useGetMetabaseBigQueryRestrictedDatasetPeriodically(dataset.id)
 
   const datasetStatus = hasAllUsers ? openDatasetStatus : restrictedDatasetStatus
+
   const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false)
   const [showOpenRestrictedMetabaseConfirm, setShowOpenRestrictedMetabaseConfirm] = React.useState(false)
-  const [openingMetabaseDatabase, setOpeningMetabaseDatabase] = React.useState(false)
 
   const handleReset = () => {
     clearMetabaseJobs.mutate()
@@ -72,21 +72,16 @@ const MetabaseBigQueryIntegration: React.FC<MetabaseBigQueryLinkProps> = (
     } else {
       deleteRestrictedDataset.mutate()
     }
-
-    setTimeout(() => {
-      window.location.reload()
-      setShowDeleteConfirm(false)
-    }, 5000)
+    setShowDeleteConfirm(false)
   }
 
   const handleOpenRestrictedMetabaseDatabase = () => {
-    setOpeningMetabaseDatabase(true)
     if (hasAllUsers) openRestrictedDataset.mutate()
-    setTimeout(() => {
-      window.location.reload()
-      setShowOpenRestrictedMetabaseConfirm(false)
-    }, 5000)
+    setShowOpenRestrictedMetabaseConfirm(false)
   }
+
+  const isDeleting = deleteOpenDataset.isPending || deleteRestrictedDataset.isPending
+  const isOpeningRestricted = openRestrictedDataset.isPending
 
   // If URL exists, show the link
   if (dataset.metabaseDataset?.URL) {
@@ -115,7 +110,7 @@ const MetabaseBigQueryIntegration: React.FC<MetabaseBigQueryLinkProps> = (
               onClick={handleOpenRestrictedMetabaseDatabase}
               variant="primary"
               size="small"
-              disabled={openingMetabaseDatabase}
+              disabled={openRestrictedDataset.isPending}
             >
               Bekreft
             </Button>
@@ -126,7 +121,7 @@ const MetabaseBigQueryIntegration: React.FC<MetabaseBigQueryLinkProps> = (
             >
               Avbryt
             </Button>
-            {openingMetabaseDatabase && <Loader />}
+            {openRestrictedDataset.isPending && <Loader />}
           </Modal.Footer>
         </Modal>
         <a
@@ -150,28 +145,44 @@ const MetabaseBigQueryIntegration: React.FC<MetabaseBigQueryLinkProps> = (
               confirmText="Jeg forstår at datasettet fjernes fra Metabase og at dette ikke kan angres."
             />
             <div className='flex flex-col gap-1'>
-              <a
-                className="border-l-8 border-ax-border-neutral-subtle pl-4 py-1 pr-4 w-fit mt-2"
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault()
-                  setShowDeleteConfirm(true)
-                }}
-              >
-                Fjern datasettet fra Metabase
-              </a>
-              <a>
-                {hasAllUsers && dataset.metabaseDataset?.Type === "restricted" && <a
-                  className="border-l-8 border-ax-border-neutral-subtle pl-4 py-1 pr-4 w-fit"
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    setShowOpenRestrictedMetabaseConfirm(true)
-                  }}
-                >
-                  Åpne opp datasett i Metabase for alle i Nav
-                </a>}
-              </a>
+              {isDeleting ? (
+                <p className="border-l-8 border-ax-border-neutral-subtle py-1 px-4 flex flex-row gap-2 w-fit text-ax-text-neutral-subtle mt-2">
+                  Fjerner fra Metabase
+                  <Loader transparent size="small" />
+                </p>
+              ) : (
+                <>
+                  <a
+                    className="border-l-8 border-ax-border-neutral-subtle pl-4 py-1 pr-4 w-fit mt-2"
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      setShowDeleteConfirm(true)
+                    }}
+                  >
+                    Fjern datasettet fra Metabase
+                  </a>
+                  {hasAllUsers && dataset.metabaseDataset?.Type === "restricted" && (
+                    isOpeningRestricted ? (
+                      <p className="border-l-8 border-ax-border-neutral-subtle py-1 px-4 flex flex-row gap-2 w-fit text-ax-text-neutral-subtle">
+                        Åpner for alle i Nav
+                        <Loader transparent size="small" />
+                      </p>
+                    ) : (
+                      <a
+                        className="border-l-8 border-ax-border-neutral-subtle pl-4 py-1 pr-4 w-fit"
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault()
+                          setShowOpenRestrictedMetabaseConfirm(true)
+                        }}
+                      >
+                        Åpne opp datasett i Metabase for alle i Nav
+                      </a>
+                    )
+                  )}
+                </>
+              )}
             </div>
           </>
         )}

--- a/frontend/components/dataproducts/queries.tsx
+++ b/frontend/components/dataproducts/queries.tsx
@@ -1,4 +1,5 @@
 import { createQueryKeyStore } from '@lukemorales/query-key-factory'
+import { useEffect, useRef } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { MetabaseBigQueryDatasetStatus } from '../../lib/rest/generatedDto'
 import { HttpError } from '../../lib/rest/request'
@@ -19,12 +20,27 @@ export const queries = createQueryKeyStore({
   },
 })
 
-export const useGetMetabaseBigQueryRestrictedDatasetPeriodically = (datasetId: string) =>
-  useQuery<MetabaseBigQueryDatasetStatus, HttpError>({
+// Invalidates the dataset query when river jobs finish (isRunning: true → false)
+const useInvalidateDatasetOnJobCompletion = (datasetId: string, isRunning: boolean | undefined) => {
+  const queryClient = useQueryClient()
+  const prevIsRunning = useRef<boolean | undefined>(undefined)
+  useEffect(() => {
+    if (prevIsRunning.current === true && isRunning === false) {
+      queryClient.invalidateQueries({ queryKey: ["dataset", datasetId] }).then((r) => console.log(r))
+    }
+    prevIsRunning.current = isRunning
+  }, [isRunning, queryClient, datasetId])
+}
+
+export const useGetMetabaseBigQueryRestrictedDatasetPeriodically = (datasetId: string) => {
+  const result = useQuery<MetabaseBigQueryDatasetStatus, HttpError>({
     ...queries.dataproducts.metabaseBigQueryRestrictedDataset(datasetId),
     queryFn: () => getMetabaseBigQueryRestrictedDataset(datasetId),
-    refetchInterval: 5000,
+    refetchInterval: (query) => query.state.data?.isRunning ? 5000 : false,
   })
+  useInvalidateDatasetOnJobCompletion(datasetId, result.data?.isRunning)
+  return result
+}
 
 export const useCreateMetabaseBigQueryRestrictedDataset = (datasetId: string) => {
   const queryClient = useQueryClient()
@@ -44,16 +60,20 @@ export const useDeleteMetabaseBigQueryRestrictedDataset = (datasetId: string) =>
     mutationFn: () => deleteMetabaseBigQueryRestrictedDataset(datasetId),
     onSuccess: () => {
       queryClient.invalidateQueries(queries.dataproducts.metabaseBigQueryRestrictedDataset(datasetId)).then((r) => console.log(r))
+      queryClient.invalidateQueries({ queryKey: ["dataset", datasetId] }).then((r) => console.log(r))
     },
   })
 }
 
-export const useGetMetabaseBigQueryOpenDatasetPeriodically = (datasetId: string) =>
-  useQuery<MetabaseBigQueryDatasetStatus, HttpError>({
+export const useGetMetabaseBigQueryOpenDatasetPeriodically = (datasetId: string) => {
+  const result = useQuery<MetabaseBigQueryDatasetStatus, HttpError>({
     ...queries.dataproducts.metabaseBigQueryOpenDataset(datasetId),
     queryFn: () => getMetabaseBigQueryOpenDataset(datasetId),
-    refetchInterval: 5000,
+    refetchInterval: (query) => query.state.data?.isRunning ? 5000 : false,
   })
+  useInvalidateDatasetOnJobCompletion(datasetId, result.data?.isRunning)
+  return result
+}
 
 export const useCreateMetabaseBigQueryOpenDataset = (datasetId: string) => {
   const queryClient = useQueryClient()
@@ -73,6 +93,7 @@ export const useOpenRestrictedMetabaseBigQueryDataset = (datasetId: string) => {
     mutationFn: () => openRestrictedMetabaseBigQueryDataset(datasetId),
     onSuccess: () => {
       queryClient.invalidateQueries(queries.dataproducts.metabaseBigQueryOpenDataset(datasetId)).then((r) => console.log(r))
+      queryClient.invalidateQueries({ queryKey: ['dataset', datasetId] }).then((r) => console.log(r))
     },
   })
 }
@@ -84,6 +105,7 @@ export const useDeleteMetabaseBigQueryOpenDataset = (datasetId: string) => {
     mutationFn: () => deleteMetabaseBigQueryOpenDataset(datasetId),
     onSuccess: () => {
       queryClient.invalidateQueries(queries.dataproducts.metabaseBigQueryOpenDataset(datasetId)).then((r) => console.log(r))
+      queryClient.invalidateQueries({ queryKey: ["dataset", datasetId] }).then((r) => console.log(r))
     },
   })
 }


### PR DESCRIPTION
 After adding or removing a BigQuery dataset from Metabase, the UI now
 updates automatically when river jobs complete, instead of requiring a
 manual page reload.

 - Poll job status only while isRunning, not continuously
 - Invalidate the dataset query when jobs finish (isRunning: true → false)
 - Invalidate the dataset query directly on delete and open-restricted mutations
 - Show inline spinner while delete and open-restricted operations are pending
 - Remove setTimeout + window.location.reload() hacks