### PR TITLE
feat(CI): Build frontend outside Docker and use chainguard node image.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,6 @@ updates:
       default-days: 7 
   - package-ecosystem: "docker"
     directories: 
-      - "/frontend"
       - "/resources/images/nada-backend"
     schedule:
       interval: "weekly"

--- a/.github/workflows/build-and-deploy-frontend.yml
+++ b/.github/workflows/build-and-deploy-frontend.yml
@@ -32,15 +32,38 @@ jobs:
         run: |
           echo "environment: ${{ inputs.deploy_env }}"
       - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Enable pnpm
+        run: corepack enable pnpm
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+
+      - name: Build
+        working-directory: frontend
+        run: pnpm build
+        env:
+          NODE_ENV: production
+          NEXT_PUBLIC_ENV: production
+          NEXT_PUBLIC_BACKEND: http://nada-backend/api
+
+      - name: Prune dev dependencies
+        working-directory: frontend
+        run: pnpm prune --prod
+
       - name: Push docker image to GAR
         uses: nais/docker-build-push@v0
         id: docker-build-push
         with:
           team: nada
           docker_context: frontend
-          build_secrets: NODE_AUTH_TOKEN=${{ secrets.READER_TOKEN }}          
-          build_args: 
-            NODE_AUTH_TOKEN=${{secrets.READER_TOKEN}}
           image_suffix: frontend
 
   deploy-dev:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,6 +1,5 @@
 dist
 .dockerignore
-node_modules
 yarn-error.log
 .yarnclean
 Dockerfile

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,53 +1,11 @@
-# Dependencies
-FROM node:25.8.1-alpine AS dependencies
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24-slim
 
 WORKDIR /usr/app
-
-RUN npm install -g pnpm
-
-COPY package.json pnpm-lock.yaml ./
-
-RUN --mount=type=secret,id=NODE_AUTH_TOKEN \
-    printf "//npm.pkg.github.com/:_authToken=%s\n" \
-    "$(cat /run/secrets/NODE_AUTH_TOKEN)" > .npmrc && \
-    pnpm install --frozen-lockfile && \
-    rm -f .npmrc
-
-# Builder
-FROM node:25.8.1-alpine AS builder
-
-WORKDIR /usr/app
-RUN npm install -g pnpm
-
-COPY --from=dependencies /usr/app/node_modules ./node_modules
-COPY . .
 
 ENV NODE_ENV=production
-ENV NEXT_PUBLIC_ENV=production
-ENV NEXT_PUBLIC_BACKEND=http://nada-backend/api
 
-RUN pnpm build
+COPY --chown=nonroot:nonroot node_modules ./node_modules
+COPY --chown=nonroot:nonroot .next ./.next
+COPY --chown=nonroot:nonroot public ./public
 
-
-# Runtime
-FROM node:25.8.1-alpine AS runtime
-
-WORKDIR /usr/app
-RUN npm install -g pnpm
-
-ENV NODE_ENV=production
-ENV NEXT_PUBLIC_ENV=production
-ENV NEXT_PUBLIC_BACKEND=http://nada-backend/api
-
-COPY package.json pnpm-lock.yaml ./
-
-RUN --mount=type=secret,id=NODE_AUTH_TOKEN \
-    printf "//npm.pkg.github.com/:_authToken=%s\n" \
-    "$(cat /run/secrets/NODE_AUTH_TOKEN)" > .npmrc && \
-    pnpm install --prod --frozen-lockfile && \
-    rm -f .npmrc
-
-COPY --from=builder /usr/app/.next ./.next
-COPY --from=builder /usr/app/public ./public
-
-CMD ["pnpm", "start"]
+CMD ["node_modules/next/dist/bin/next", "start"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,13 +1,18 @@
 ## Prerequisites:
 
-Install [Node18](https://nodejs.org/en) or later
+Install [Node 24](https://nodejs.org/en) (LTS) or later.
 
 Install pnpm
 ````
 RUN npm install -g pnpm
 ````
 
-Install dependencies:
+Set your GitHub token (with `read:packages` scope) in your shell profile (e.g. `~/.zshrc`):
+```
+export NPM_AUTH_TOKEN=<your-github-token>
+```
+
+Then install dependencies:
 ```
 pnpm install
 ```
@@ -18,13 +23,33 @@ export PATH=./node_modules/.bin:$PATH
 ```
 
 ## Development
-First, run the development server:
+
+Run the development server:
 
 ```bash
-$ pnpm dev
+pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Building the Docker image locally
+
+The Docker image expects the app to be built outside of Docker. Run these steps from the `frontend/` directory first:
+
+```bash
+pnpm install --frozen-lockfile
+NODE_ENV=production NEXT_PUBLIC_ENV=production NEXT_PUBLIC_BACKEND=http://nada-backend/api pnpm build
+pnpm prune --prod
+```
+
+Then build and run the image from the repo root:
+
+```bash
+docker build -t nada-markedsplassen-frontend frontend/
+docker run -p 3001:3000 nada-markedsplassen-frontend
+```
+
+Open [http://localhost:3001](http://localhost:3001). Port 3001 is used to avoid conflicts with local dev servers on 3000.
 
 ### Storybooks
 


### PR DESCRIPTION
- Build the frontend in CI for a simpler Dockerfile.
- Switch to chainguard node 24 (LTS)
- Update README with new build recipe