### PR TITLE
refactor(workstation): fan-out URL list sync

### DIFF
--- a/pkg/service/core/queue/river/river_workstations.go
+++ b/pkg/service/core/queue/river/river_workstations.go
@@ -739,6 +739,63 @@ func (q *workstationsQueue) CreateWorkstationsResyncAllWorkflow(ctx context.Cont
 	return nil
 }
 
+func (q *workstationsQueue) CreateEnsureURLListForIdentJobs(ctx context.Context, idents []*service.WorkstationURLListUser) error {
+	const op errs.Op = "workstationsQueue.CreateEnsureURLListForIdentJobs"
+
+	if len(idents) == 0 {
+		return nil
+	}
+
+	client, err := NewClient(q.repo, q.config)
+	if err != nil {
+		return errs.E(errs.Database, service.CodeTransactionalQueue, op, err)
+	}
+
+	tx, err := q.repo.GetDBX().BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return errs.E(errs.Database, service.CodeTransactionalQueue, op, err)
+	}
+	defer tx.Rollback(ctx)
+
+	insertOpts := &river.InsertOpts{
+		MaxAttempts: 5,
+		UniqueOpts: river.UniqueOpts{
+			ByArgs:   true,
+			ByPeriod: 10 * time.Minute,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRunning,
+				rivertype.JobStateRetryable,
+				rivertype.JobStateScheduled,
+			},
+		},
+		Queue: worker_args.PeriodicEnsureURLListQueue,
+	}
+
+	insertManyParams := make([]river.InsertManyParams, len(idents))
+	for idx, ident := range idents {
+		insertManyParams[idx] = river.InsertManyParams{
+			Args: &worker_args.WorkstationEnsureURLListForIdent{
+				Ident: ident.NavIdent,
+			},
+			InsertOpts: insertOpts,
+		}
+	}
+
+	_, err = client.InsertManyTx(ctx, tx, insertManyParams)
+	if err != nil {
+		return errs.E(errs.Database, service.CodeTransactionalQueue, op, err)
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		return errs.E(errs.Database, service.CodeTransactionalQueue, op, fmt.Errorf("transaction: %w", err))
+	}
+
+	return nil
+}
+
 func workstationJobMetadata(ident string) string {
 	return fmt.Sprintf(`{"ident": "%s"}`, ident)
 }

--- a/pkg/service/core/queue/river/river_workstations_test.go
+++ b/pkg/service/core/queue/river/river_workstations_test.go
@@ -182,6 +182,57 @@ func TestWorkstationsQueue_CreateWorkstationConnectivityWorkflow(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestWorkstationsQueue_CreateEnsureURLListForIdentJobs(t *testing.T) {
+	log := zerolog.New(zerolog.NewConsoleWriter()).Level(zerolog.InfoLevel)
+	ctx := context.Background()
+
+	c := integration.NewContainers(t, log)
+	defer c.Cleanup()
+
+	pgCfg := c.RunPostgres(integration.NewPostgresConfig())
+
+	repo, err := database.New(
+		pgCfg.ConnectionURL(),
+		10,
+		10,
+	)
+	require.NoError(t, err)
+
+	workers := river.NewWorkers()
+	config := worker.RiverConfig(&log, workers)
+	config.PeriodicJobs = []*river.PeriodicJob{}
+	config.TestOnly = true
+
+	err = worker.WorkstationAddWorkers(config, &workstationServiceMock{}, repo)
+	require.NoError(t, err)
+
+	store := riverstore.NewWorkstationsQueue(config, repo)
+	idents := []*service.WorkstationURLListUser{
+		{NavIdent: "x123456"},
+		{NavIdent: "x123457"},
+	}
+
+	err = store.CreateEnsureURLListForIdentJobs(ctx, idents)
+	require.NoError(t, err)
+
+	_ = rivertest.RequireManyInserted(ctx, t, riverdatabasesql.New(repo.GetDB()), []rivertest.ExpectedJob{
+		{
+			Args: &worker_args.WorkstationEnsureURLListForIdent{Ident: "x123456"},
+		},
+		{
+			Args: &worker_args.WorkstationEnsureURLListForIdent{Ident: "x123457"},
+		},
+	})
+
+	err = store.CreateEnsureURLListForIdentJobs(ctx, idents)
+	require.NoError(t, err)
+
+	var count int
+	err = repo.GetDBX().QueryRow(ctx, "SELECT COUNT(*) FROM river_job WHERE kind = $1", worker_args.WorkstationEnsureURLListForIdentKind).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, len(idents), count)
+}
+
 func TestJobDifference(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/core/service_workstations.go
+++ b/pkg/service/core/service_workstations.go
@@ -334,6 +334,26 @@ func (s *workstationService) GetWorkstationURLListUsers(ctx context.Context) ([]
 
 }
 
+func (s *workstationService) CreateEnsureURLListJobsForAllIdents(ctx context.Context) error {
+	const op errs.Op = "workstationService.CreateEnsureURLListJobsForAllIdents"
+
+	idents, err := s.workstationStorage.GetWorkstationURLListUsers(ctx)
+	if err != nil {
+		return errs.E(op, err)
+	}
+
+	if len(idents) == 0 {
+		return nil
+	}
+
+	err = s.workstationsQueue.CreateEnsureURLListForIdentJobs(ctx, idents)
+	if err != nil {
+		return errs.E(op, err)
+	}
+
+	return nil
+}
+
 func (s *workstationService) DeleteWorkstationURLListItemForIdent(ctx context.Context, id uuid.UUID) error {
 	const op errs.Op = "workstationService.DeleteWorkstationURLListItemForIdent"
 

--- a/pkg/service/workstations.go
+++ b/pkg/service/workstations.go
@@ -122,6 +122,9 @@ type WorkstationsService interface {
 	// GetWorkstationURLListUsers gets the users that uses URLLists
 	GetWorkstationURLListUsers(ctx context.Context) ([]*WorkstationURLListUser, error)
 
+	// CreateEnsureURLListJobsForAllIdents fetches all URL list users and inserts per-ident jobs
+	CreateEnsureURLListJobsForAllIdents(ctx context.Context) error
+
 	// CreateWorkstationStartJob creates a job to start the workstation
 	CreateWorkstationStartJob(ctx context.Context, user *User) (*WorkstationStartJob, error)
 
@@ -217,6 +220,9 @@ type WorkstationsQueue interface {
 	CreateWorkstationJob(ctx context.Context, opts *WorkstationJobOpts) (*WorkstationJob, error)
 	GetWorkstationJobsForUser(ctx context.Context, ident string) ([]*WorkstationJob, error)             // filter: running
 	GetWorkstationResyncJobsForUser(ctx context.Context, ident string) ([]*WorkstationResyncJob, error) // filter: running
+
+	// CreateEnsureURLListForIdentJobs bulk-inserts per-ident URL list sync jobs
+	CreateEnsureURLListForIdentJobs(ctx context.Context, idents []*WorkstationURLListUser) error
 
 	GetWorkstationStartJob(ctx context.Context, id int64) (*WorkstationStartJob, error)
 	CreateWorkstationStartJob(ctx context.Context, ident string) (*WorkstationStartJob, error)

--- a/pkg/worker/worker_args/workstation.go
+++ b/pkg/worker/worker_args/workstation.go
@@ -12,6 +12,7 @@ const (
 	WorkstationNotifyKind        = "workstation_notify"
 	WorkstationResyncKind        = "workstation_resync"
 	WorkstationEnsureURLListKind = "workstation_ensure_url_list"
+	WorkstationEnsureURLListForIdentKind = "workstation_ensure_url_list_for_ident"
 
 	ConfigWorkstationSSHKind = "workstation_ssh_config"
 
@@ -149,4 +150,12 @@ type WorkstationEnsureURLList struct{}
 
 func (WorkstationEnsureURLList) Kind() string {
 	return WorkstationEnsureURLListKind
+}
+
+type WorkstationEnsureURLListForIdent struct {
+	Ident string `json:"ident" river:"unique"`
+}
+
+func (WorkstationEnsureURLListForIdent) Kind() string {
+	return WorkstationEnsureURLListForIdentKind
 }

--- a/pkg/worker/workstation.go
+++ b/pkg/worker/workstation.go
@@ -333,29 +333,36 @@ type WorkstationEnsureURLList struct {
 	river.WorkerDefaults[worker_args.WorkstationEnsureURLList]
 
 	service service.WorkstationsService
-	repo    *database.Repo
 }
 
 func (w *WorkstationEnsureURLList) Work(ctx context.Context, job *river.Job[worker_args.WorkstationEnsureURLList]) error {
-	idents, err := w.service.GetWorkstationURLListUsers(ctx)
+	err := w.service.CreateEnsureURLListJobsForAllIdents(ctx)
 	if err != nil {
-		return fmt.Errorf("getting all workstation idents: %w", err)
+		return fmt.Errorf("creating ensure url list jobs: %w", err)
 	}
 
-	for _, ident := range idents {
-		urlList, err := w.service.GetWorkstationActiveURLListForIdent(ctx, &service.User{Ident: ident.NavIdent})
-		if err != nil {
-			return fmt.Errorf("getting workstation active urllist for ident %s: %w", ident, err)
-		}
+	return nil
+}
 
-		err = w.service.EnsureWorkstationURLList(ctx, &service.WorkstationActiveURLListForIdent{
-			Slug:                 ident.NavIdent,
-			URLList:              urlList.URLList,
-			DisableGlobalURLList: urlList.DisableGlobalURLList,
-		})
-		if err != nil {
-			return fmt.Errorf("ensuring workstation urllist for ident %s: %w", ident, err)
-		}
+type WorkstationEnsureURLListForIdent struct {
+	river.WorkerDefaults[worker_args.WorkstationEnsureURLListForIdent]
+
+	service service.WorkstationsService
+}
+
+func (w *WorkstationEnsureURLListForIdent) Work(ctx context.Context, job *river.Job[worker_args.WorkstationEnsureURLListForIdent]) error {
+	urlList, err := w.service.GetWorkstationActiveURLListForIdent(ctx, &service.User{Ident: job.Args.Ident})
+	if err != nil {
+		return fmt.Errorf("getting workstation active urllist for ident %s: %w", job.Args.Ident, err)
+	}
+
+	err = w.service.EnsureWorkstationURLList(ctx, &service.WorkstationActiveURLListForIdent{
+		Slug:                 job.Args.Ident,
+		URLList:              urlList.URLList,
+		DisableGlobalURLList: urlList.DisableGlobalURLList,
+	})
+	if err != nil {
+		return fmt.Errorf("ensuring workstation urllist for ident %s: %w", job.Args.Ident, err)
 	}
 
 	return nil
@@ -437,10 +444,17 @@ func WorkstationAddWorkers(config *riverpro.Config, service service.Workstations
 	err = river.AddWorkerSafely[worker_args.WorkstationEnsureURLList](config.Workers, &WorkstationEnsureURLList{
 		WorkerDefaults: river.WorkerDefaults[worker_args.WorkstationEnsureURLList]{},
 		service:        service,
-		repo:           repo,
 	})
 	if err != nil {
 		return fmt.Errorf("adding workstation ensure urllist worker: %w", err)
+	}
+
+	err = river.AddWorkerSafely[worker_args.WorkstationEnsureURLListForIdent](config.Workers, &WorkstationEnsureURLListForIdent{
+		WorkerDefaults: river.WorkerDefaults[worker_args.WorkstationEnsureURLListForIdent]{},
+		service:        service,
+	})
+	if err != nil {
+		return fmt.Errorf("adding workstation ensure urllist for ident worker: %w", err)
 	}
 
 	return nil

--- a/pkg/worker/workstation_test.go
+++ b/pkg/worker/workstation_test.go
@@ -1,0 +1,96 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/navikt/nada-backend/pkg/service"
+	"github.com/navikt/nada-backend/pkg/worker/worker_args"
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type workstationURLListServiceMock struct {
+	service.WorkstationsService
+	getActiveURLList func(ctx context.Context, user *service.User) (*service.WorkstationActiveURLListForIdent, error)
+	ensureURLList    func(ctx context.Context, input *service.WorkstationActiveURLListForIdent) error
+}
+
+func (m *workstationURLListServiceMock) GetWorkstationActiveURLListForIdent(ctx context.Context, user *service.User) (*service.WorkstationActiveURLListForIdent, error) {
+	return m.getActiveURLList(ctx, user)
+}
+
+func (m *workstationURLListServiceMock) EnsureWorkstationURLList(ctx context.Context, input *service.WorkstationActiveURLListForIdent) error {
+	return m.ensureURLList(ctx, input)
+}
+
+func TestWorkstationEnsureURLListForIdent_Work_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	ident := "nav-ident-1"
+
+	expectedURLList := &service.WorkstationActiveURLListForIdent{
+		Slug:                 ident,
+		URLList:              []string{"https://example.com", "https://other.com"},
+		DisableGlobalURLList: true,
+	}
+
+	var capturedInput *service.WorkstationActiveURLListForIdent
+
+	mock := &workstationURLListServiceMock{
+		getActiveURLList: func(ctx context.Context, user *service.User) (*service.WorkstationActiveURLListForIdent, error) {
+			assert.Equal(t, ident, user.Ident)
+			return expectedURLList, nil
+		},
+		ensureURLList: func(ctx context.Context, input *service.WorkstationActiveURLListForIdent) error {
+			capturedInput = input
+			return nil
+		},
+	}
+
+	w := &WorkstationEnsureURLListForIdent{
+		service: mock,
+	}
+
+	job := &river.Job[worker_args.WorkstationEnsureURLListForIdent]{
+		Args: worker_args.WorkstationEnsureURLListForIdent{Ident: ident},
+	}
+
+	err := w.Work(ctx, job)
+	require.NoError(t, err)
+
+	require.NotNil(t, capturedInput)
+	assert.Equal(t, ident, capturedInput.Slug)
+	assert.Equal(t, expectedURLList.URLList, capturedInput.URLList)
+	assert.Equal(t, expectedURLList.DisableGlobalURLList, capturedInput.DisableGlobalURLList)
+}
+
+func TestWorkstationEnsureURLListForIdent_Work_GetURLListError(t *testing.T) {
+	ctx := context.Background()
+	ident := "nav-ident-2"
+	expectedErr := errors.New("service unavailable")
+
+	mock := &workstationURLListServiceMock{
+		getActiveURLList: func(ctx context.Context, user *service.User) (*service.WorkstationActiveURLListForIdent, error) {
+			return nil, expectedErr
+		},
+		ensureURLList: func(ctx context.Context, input *service.WorkstationActiveURLListForIdent) error {
+			t.Fatal("EnsureWorkstationURLList should not be called when GetWorkstationActiveURLListForIdent fails")
+			return nil
+		},
+	}
+
+	w := &WorkstationEnsureURLListForIdent{
+		service: mock,
+	}
+
+	job := &river.Job[worker_args.WorkstationEnsureURLListForIdent]{
+		Args: worker_args.WorkstationEnsureURLListForIdent{Ident: ident},
+	}
+
+	err := w.Work(ctx, job)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, ident)
+	assert.ErrorContains(t, err, "getting workstation active urllist")
+}

--- a/pkg/worker/workstation_test.go
+++ b/pkg/worker/workstation_test.go
@@ -14,8 +14,9 @@ import (
 
 type workstationURLListServiceMock struct {
 	service.WorkstationsService
-	getActiveURLList func(ctx context.Context, user *service.User) (*service.WorkstationActiveURLListForIdent, error)
-	ensureURLList    func(ctx context.Context, input *service.WorkstationActiveURLListForIdent) error
+	getActiveURLList              func(ctx context.Context, user *service.User) (*service.WorkstationActiveURLListForIdent, error)
+	ensureURLList                 func(ctx context.Context, input *service.WorkstationActiveURLListForIdent) error
+	createEnsureURLListJobsForAll func(ctx context.Context) error
 }
 
 func (m *workstationURLListServiceMock) GetWorkstationActiveURLListForIdent(ctx context.Context, user *service.User) (*service.WorkstationActiveURLListForIdent, error) {
@@ -24,6 +25,10 @@ func (m *workstationURLListServiceMock) GetWorkstationActiveURLListForIdent(ctx 
 
 func (m *workstationURLListServiceMock) EnsureWorkstationURLList(ctx context.Context, input *service.WorkstationActiveURLListForIdent) error {
 	return m.ensureURLList(ctx, input)
+}
+
+func (m *workstationURLListServiceMock) CreateEnsureURLListJobsForAllIdents(ctx context.Context) error {
+	return m.createEnsureURLListJobsForAll(ctx)
 }
 
 func TestWorkstationEnsureURLListForIdent_Work_HappyPath(t *testing.T) {
@@ -93,4 +98,78 @@ func TestWorkstationEnsureURLListForIdent_Work_GetURLListError(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, ident)
 	assert.ErrorContains(t, err, "getting workstation active urllist")
+}
+
+func TestWorkstationEnsureURLListForIdent_Work_EnsureURLListError(t *testing.T) {
+	ctx := context.Background()
+	ident := "nav-ident-3"
+	expectedErr := errors.New("gcp write failed")
+
+	mock := &workstationURLListServiceMock{
+		getActiveURLList: func(ctx context.Context, user *service.User) (*service.WorkstationActiveURLListForIdent, error) {
+			return &service.WorkstationActiveURLListForIdent{
+				Slug:    ident,
+				URLList: []string{"https://example.com"},
+			}, nil
+		},
+		ensureURLList: func(ctx context.Context, input *service.WorkstationActiveURLListForIdent) error {
+			return expectedErr
+		},
+	}
+
+	w := &WorkstationEnsureURLListForIdent{
+		service: mock,
+	}
+
+	job := &river.Job[worker_args.WorkstationEnsureURLListForIdent]{
+		Args: worker_args.WorkstationEnsureURLListForIdent{Ident: ident},
+	}
+
+	err := w.Work(ctx, job)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, ident)
+	assert.ErrorContains(t, err, "ensuring workstation urllist")
+}
+
+func TestWorkstationEnsureURLList_Work_HappyPath(t *testing.T) {
+	ctx := context.Background()
+
+	called := false
+	mock := &workstationURLListServiceMock{
+		createEnsureURLListJobsForAll: func(ctx context.Context) error {
+			called = true
+			return nil
+		},
+	}
+
+	w := &WorkstationEnsureURLList{
+		service: mock,
+	}
+
+	job := &river.Job[worker_args.WorkstationEnsureURLList]{}
+
+	err := w.Work(ctx, job)
+	require.NoError(t, err)
+	assert.True(t, called, "CreateEnsureURLListJobsForAllIdents should have been called")
+}
+
+func TestWorkstationEnsureURLList_Work_CreateJobsError(t *testing.T) {
+	ctx := context.Background()
+	expectedErr := errors.New("db connection lost")
+
+	mock := &workstationURLListServiceMock{
+		createEnsureURLListJobsForAll: func(ctx context.Context) error {
+			return expectedErr
+		},
+	}
+
+	w := &WorkstationEnsureURLList{
+		service: mock,
+	}
+
+	job := &river.Job[worker_args.WorkstationEnsureURLList]{}
+
+	err := w.Work(ctx, job)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "creating ensure url list jobs")
 }


### PR DESCRIPTION
Replaces the single sequential WorkstationEnsureURLList worker with a fan-out pattern. 

The periodic job now bulk-inserts one River job per NAV-ident via CreateEnsureURLListForIdentJobs, and a new WorkstationEnsureURLListForIdent worker handles each user in isolation. Jobs are deduplicated by ident within a 10-minute window using River's UniqueOpts. This improves resilience (one failure no longer blocks all users) and enables parallel processing.