### PR TITLE
Metabase bugfix

### DIFF
--- a/frontend/components/dataproducts/metabaseSync.tsx
+++ b/frontend/components/dataproducts/metabaseSync.tsx
@@ -86,7 +86,7 @@ export const MetabaseSync: React.FC<MetabaseSyncProps> = ({ status, handleReset 
             En jobb har feilet. Vennligst kontakt administrator hvis problemet vedvarer.
           </Alert>
           <div className="mt-2">
-            <Button icon={<ArrowsCirclepathIcon title="Prøv igjen" onClick={handleReset}/>} >
+            <Button icon={<ArrowsCirclepathIcon title="Prøv igjen" />} onClick={handleReset}>
               Prøv igjen
             </Button>
           </div>

--- a/frontend/lib/rest/dataproducts.ts
+++ b/frontend/lib/rest/dataproducts.ts
@@ -85,12 +85,15 @@ export const deleteMetabaseBigqueryJobs = async (datasetId: string) =>
 export const useGetDataproduct = (id: string, activeDataSetID?: string) =>
     useQuery<DataproductWithDataset, HttpError>({
         queryKey: ['dataproduct', id, activeDataSetID],
-        queryFn: ()=>getDataproduct(id)
+        queryFn: ()=>getDataproduct(id),
+        enabled: !!id,
     })
 
 export const useGetDataset = (id: string) => useQuery<DatasetWithAccess>({
     queryKey: ['dataset', id],
-    queryFn: ()=>getDataset(id)})
+    queryFn: ()=>getDataset(id),
+    enabled: !!id,
+})
 
 export const useGetAccessiblePseudoDatasets = () =>
     useQuery<PseudoDataset[], HttpError>({

--- a/pkg/service/core/api/http/http_metabase.go
+++ b/pkg/service/core/api/http/http_metabase.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -968,43 +967,13 @@ func dbExists(dbs []service.MetabaseDatabase, nadaID string) (int, bool) {
 	return 0, false
 }
 
-// retryOnEOFTransport retries requests once on EOF. Go auto-retries GET/HEAD on
-// stale keep-alive connections, but not POST/PUT/DELETE.
-type retryOnEOFTransport struct {
-	base http.RoundTripper
-}
-
-func (t *retryOnEOFTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	resp, err := t.base.RoundTrip(req)
-	if err == nil || !errors.Is(err, io.EOF) {
-		return resp, err
-	}
-
-	retryReq := req.Clone(req.Context())
-
-	if req.Body == nil {
-		return t.base.RoundTrip(retryReq)
-	}
-
-	if req.GetBody != nil {
-		body, bodyErr := req.GetBody()
-		if bodyErr != nil {
-			return resp, err
-		}
-
-		retryReq.Body = body
-
-		return t.base.RoundTrip(retryReq)
-	}
-
-	return resp, err
-}
-
 func NewMetabaseHTTP(url, username, password, endpoint string, disableAuth, debug bool, log zerolog.Logger) *metabaseAPI {
 	return &metabaseAPI{
 		c: &http.Client{
-			Timeout:   time.Second * 300, //nolint:gomnd
-			Transport: &retryOnEOFTransport{base: http.DefaultTransport},
+			Timeout: time.Second * 300, //nolint:gomnd
+			Transport: &http.Transport{
+				DisableKeepAlives: true,
+			},
 		},
 		url:         url,
 		password:    password,

--- a/pkg/service/core/api/http/http_metabase_test.go
+++ b/pkg/service/core/api/http/http_metabase_test.go
@@ -1,0 +1,136 @@
+package http_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	mbhttp "github.com/navikt/nada-backend/pkg/service/core/api/http"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMetabaseTestServer creates a minimal httptest server that handles the
+// two endpoints exercised by the Metabase client in these tests:
+//   - POST /session  — returns a fake session token
+//   - PUT  /table    — returns 200 OK
+//
+// If closeAfterResponse is true the handler hijacks the underlying TCP
+// connection and writes a complete HTTP response manually before closing,
+// simulating Metabase's Jetty server silently closing keep-alive connections
+// after its idle timeout.
+func newMetabaseTestServer(t *testing.T, closeAfterResponse bool) (srv *httptest.Server, newConns *atomic.Int32) {
+	t.Helper()
+
+	newConns = new(atomic.Int32)
+
+	srv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !closeAfterResponse {
+			switch r.URL.Path {
+			case "/session":
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]string{"id": "test-session"})
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+			return
+		}
+
+		// When simulating Jetty's connection-close behaviour we must write a
+		// complete, valid HTTP response manually. w.WriteHeader() only buffers
+		// the status code inside the ResponseWriter — the bytes are not flushed
+		// to the underlying connection until the handler returns or the first
+		// w.Write() call, so hijacking immediately after WriteHeader would
+		// leave the client with an incomplete response and an unexpected EOF.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("server does not support hijacking")
+			return
+		}
+
+		conn, buf, _ := hj.Hijack()
+		defer conn.Close()
+
+		switch r.URL.Path {
+		case "/session":
+			body := `{"id":"test-session"}`
+			_, _ = fmt.Fprintf(buf, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s", len(body), body)
+		default:
+			_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+		}
+
+		_ = buf.Flush()
+		// Close without sending Connection: close, so the client does not know
+		// the connection is gone until it tries to reuse it.
+	}))
+
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	return srv, newConns
+}
+
+// TestMetabaseClientOpensNewConnectionPerRequest asserts that every request
+// uses a fresh TCP connection. This is the property that prevents stale
+// keep-alive connections from causing EOF or "server closed idle connection"
+// errors on non-idempotent requests (PUT/POST/DELETE), which Go does not
+// auto-retry.
+//
+// With DisableKeepAlives: true the connection count must equal the number of
+// requests. Without it, connections would be reused and the count would be
+// lower, breaking the guarantee.
+func TestMetabaseClientOpensNewConnectionPerRequest(t *testing.T) {
+	t.Parallel()
+
+	const nRequests = 5
+
+	// Normal server — connections are never closed by the server so Go would
+	// happily reuse them if keep-alives were enabled on the client.
+	srv, newConns := newMetabaseTestServer(t, false)
+
+	client := mbhttp.NewMetabaseHTTP(srv.URL, "user", "pass", "", false, false, zerolog.Nop())
+
+	for range nRequests {
+		require.NoError(t, client.HideTables(context.Background(), []int{1, 2, 3}))
+	}
+
+	// The first HideTables call establishes a session (POST /session) before
+	// issuing the PUT /table request, so the expected connection count is
+	// nRequests + 1.
+	assert.Equal(t, nRequests+1, int(newConns.Load()))
+}
+
+// TestMetabaseClientSucceedsWhenServerClosesConnections asserts that all
+// requests succeed even when the server forcefully closes the TCP connection
+// after every response — without sending a Connection: close header. This
+// replicates Metabase's Jetty server behaviour that previously caused
+// intermittent failures on HideTables and ShowTables in periodic workers.
+func TestMetabaseClientSucceedsWhenServerClosesConnections(t *testing.T) {
+	t.Parallel()
+
+	const nRequests = 5
+
+	srv, newConns := newMetabaseTestServer(t, true)
+
+	client := mbhttp.NewMetabaseHTTP(srv.URL, "user", "pass", "", false, false, zerolog.Nop())
+
+	for range nRequests {
+		require.NoError(t, client.HideTables(context.Background(), []int{1, 2, 3}))
+	}
+
+	// Every request must have used its own connection because the previous one
+	// was closed by the server.
+	assert.Equal(t, nRequests+1, int(newConns.Load()))
+}

--- a/pkg/service/core/service_metabase.go
+++ b/pkg/service/core/service_metabase.go
@@ -488,6 +488,10 @@ func (s *metabaseService) GetOpenMetabaseBigQueryDatabaseWorkflow(ctx context.Co
 
 	wf, err := s.metabaseQueue.GetOpenMetabaseBigQueryDatabaseWorkflow(ctx, datasetID)
 	if err != nil {
+		if errs.KindIs(errs.NotExist, err) {
+			return &service.MetabaseBigQueryDatasetStatus{IsRestricted: false}, nil
+		}
+
 		return nil, errs.E(op, err)
 	}
 
@@ -550,6 +554,10 @@ func (s *metabaseService) GetRestrictedMetabaseBigQueryDatabaseWorkflow(ctx cont
 
 	wf, err := s.metabaseQueue.GetRestrictedMetabaseBigqueryDatabaseWorkflow(ctx, datasetID)
 	if err != nil {
+		if errs.KindIs(errs.NotExist, err) {
+			return &service.MetabaseBigQueryDatasetStatus{IsRestricted: true}, nil
+		}
+
 		return nil, errs.E(op, err)
 	}
 


### PR DESCRIPTION
This PR fixes four separate bugs. 

pkg/service/core/api/http/http_metabase.go
Removed the retryOnEOFTransport/retryOnStaleConnTransport retry logic entirely. Replaced with DisableKeepAlives: true on the HTTP transport prevents stale connection errors from Metabase's Jetty server at the source rather than retrying around them. Added a test checking that every request is on a new connection.

pkg/service/core/service_metabase.go
Two identical fixes: 
GetRestrictedMetabaseBigQueryDatabaseWorkflow and GetOpenMetabaseBigQueryDatabaseWorkflow now return {isRunning: false, isCompleted: false} instead of a 404 when no workflow has been started for a dataset (e.g. a freshly registered dataset).

frontend/components/dataproducts/metabaseSync.tsx
Bugfix: 
onClick={handleReset} was placed on the icon prop instead of the Button the "Prøv igjen" button never worked when clicked anywhere except the tiny icon.

frontend/lib/rest/dataproducts.ts
Added enabled: !!id to useGetDataproduct and useGetDataset prevents spurious GET /api/dataproducts/undefined requests during Next.js hydration before router params are available.