### PR TITLE
feat(dataset): Display Metabase sa and grant snippets for each dataset

### DIFF
--- a/frontend/components/dataproducts/dataset/viewDataset.tsx
+++ b/frontend/components/dataproducts/dataset/viewDataset.tsx
@@ -13,6 +13,7 @@ import DatasetAccess from '../access/datasetAccess'
 import NewDatasetAccess from '../access/newDatasetAccess'
 import NewAccessRequestForm from '../accessRequest/newAccessRequest'
 import Explore from '../explore'
+import MetabaseGrantSnippet from '../metabaseGrantSnippet'
 import { AccessType } from './dataset'
 import DatasetMetadata from './datasetMetadata'
 import DatasetOwnerMenu from './datasetOwnerMenu'
@@ -229,6 +230,14 @@ const ViewDataset = ({
             >
               Legg til tilgang
             </Link>
+            {dataset.metabaseDataset?.saEmail && dataset.datasource && (
+              <div className="w-full ax-2xl:max-w-[60rem]">
+                <MetabaseGrantSnippet
+                  saEmail={dataset.metabaseDataset.saEmail}
+                  datasource={dataset.datasource}
+                />
+              </div>
+            )}
           </div>
         )}
         {dataset.description && (

--- a/frontend/components/dataproducts/metabaseGrantSnippet.tsx
+++ b/frontend/components/dataproducts/metabaseGrantSnippet.tsx
@@ -1,0 +1,160 @@
+import { Alert, BodyShort, Label, ReadMore, Tabs } from '@navikt/ds-react'
+import { BigQuery, ViewTable } from '../../lib/rest/generatedDto'
+import Copy from '../lib/copy'
+
+interface MetabaseGrantSnippetProps {
+  saEmail: string
+  datasource: BigQuery
+}
+
+interface SnippetBlockProps {
+  label: string
+  code: string
+}
+
+const SnippetBlock = ({ label, code }: SnippetBlockProps) => (
+  <div className="flex flex-col gap-1">
+    <Label size="small">{label}</Label>
+    <div className="relative">
+      <pre className="bg-ax-bg-neutral-moderate rounded px-3 py-2 pr-10 text-sm font-mono overflow-x-auto whitespace-pre-wrap break-all">
+        {code}
+      </pre>
+      <div className="absolute top-2 right-2">
+        <Copy text={code} />
+      </div>
+    </div>
+  </div>
+)
+
+const MetabaseGrantSnippet = ({ saEmail, datasource }: MetabaseGrantSnippetProps) => {
+  const { projectID: project, dataset, table, tableType } = datasource
+  const isView = tableType === ViewTable
+
+  const dbtSnippet =
+    `config:
+  grants:
+    "roles/bigquery.dataViewer":
+      - "serviceAccount:${saEmail}"`
+
+  const terraformSnippet =
+    `# Tilgang til selve tabellen/viewet
+resource "google_bigquery_table_iam_member" "metabase" {
+  project    = "${project}"
+  dataset_id = "${dataset}"
+  table_id   = "${table}"
+  role       = "roles/bigquery.dataViewer"
+  member     = "serviceAccount:${saEmail}"
+}
+
+# Metadatatilgang på dataset-nivå (for at Metabase skal kunne se at tabellen/viewet eksisterer)
+resource "google_bigquery_dataset_iam_member" "metabase_metadata" {
+  project    = "${project}"
+  dataset_id = "${dataset}"
+  role       = "roles/bigquery.metadataViewer"
+  member     = "serviceAccount:${saEmail}"
+}`
+
+  const terraformViewSnippet =
+    `# Autoriser viewet på hvert kilde-dataset det leser fra:
+resource "google_bigquery_dataset_access" "authorized_view" {
+  project    = "<kilde-prosjekt>"
+  dataset_id = "<kilde-dataset>"
+
+  view {
+    project_id = "${project}"
+    dataset_id = "${dataset}"
+    table_id   = "${table}"
+  }
+}`
+
+  const sqlSnippet =
+    `-- Tilgang til selve tabellen/viewet
+GRANT \`roles/bigquery.dataViewer\`
+ON TABLE \`${project}.${dataset}.${table}\`
+TO 'serviceAccount:${saEmail}';
+
+-- Metadatatilgang på dataset-nivå (for at Metabase skal kunne se at tabellen/viewet eksisterer)
+GRANT \`roles/bigquery.metadataViewer\`
+ON SCHEMA \`${project}.${dataset}\`
+TO 'serviceAccount:${saEmail}';`
+
+  return (
+    <div>
+      <ReadMore header="Metabase-tilgang i kode">
+      <div className="flex flex-col gap-4 mt-1">
+        <BodyShort size="small" className="text-ax-text-neutral-subtle">
+          Markedsplassen setter opp Metabase-tilgangen automatisk. Hvis dbt, Terraform eller andre
+          verktøy som styrer IAM overskriver disse tilgangene, kan du legge dem eksplisitt inn i
+          koden din slik at de ikke forsvinner.
+        </BodyShort>
+
+        <div className="flex flex-col gap-1">
+          <Label size="small">Metabase-servicebruker</Label>
+          <div className="flex items-center gap-2">
+            <BodyShort size="small" className="font-mono bg-ax-bg-neutral-moderate rounded px-3 py-1">
+              {saEmail}
+            </BodyShort>
+            <Copy text={saEmail} />
+          </div>
+        </div>
+
+        {isView && (
+          <Alert variant="warning" size="small">
+            Dette er et <strong>view</strong>. I tillegg til grantene under må viewet autoriseres
+            på hvert dataset det leser fra. Se Terraform-fanen for snippet, eller gjør det i
+            BigQuery-konsollen under «Authorized views».
+          </Alert>
+        )}
+
+        <Tabs defaultValue="dbt" size="small">
+          <Tabs.List>
+            <Tabs.Tab value="dbt" label="dbt" />
+            <Tabs.Tab value="terraform" label="Terraform" />
+            <Tabs.Tab value="sql" label="BigQuery SQL" />
+          </Tabs.List>
+
+          <Tabs.Panel value="dbt" className="flex flex-col gap-3 pt-3">
+            <SnippetBlock
+              label="grants i modell-config (schema.yml eller øverst i .sql-fil)"
+              code={dbtSnippet}
+            />
+            <BodyShort size="small" className="text-ax-text-neutral-subtle">
+              💡 Bruker du dbt i både dev og prod? Bruk Jinja:{' '}
+              <code className="font-mono">
+                {"{{ [sa_dev] if target.name == 'dev' else [sa_prod] }}"}
+              </code>
+            </BodyShort>
+            <Alert variant="info" size="small">
+              dbt <code>grants</code>-config setter kun tilgang på tabell/view-nivå. Hvis dbt
+              også overskriver IAM på dataset-nivå, må <strong>metadataViewer</strong> legges
+              til via Terraform eller BigQuery SQL (se de andre fanene).
+            </Alert>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="terraform" className="flex flex-col gap-3 pt-3">
+            <SnippetBlock label="IAM-ressurser" code={terraformSnippet} />
+            {isView && (
+              <SnippetBlock
+                label="Autoriser view på kilde-dataset(s) — gjenta for hvert dataset viewet leser fra"
+                code={terraformViewSnippet}
+              />
+            )}
+          </Tabs.Panel>
+
+          <Tabs.Panel value="sql" className="flex flex-col gap-3 pt-3">
+            <SnippetBlock label="GRANT-statements" code={sqlSnippet} />
+            {isView && (
+              <Alert variant="info" size="small">
+                Autorisering av views støttes ikke via SQL — bruk Terraform eller
+                BigQuery-konsollen under «Authorized views» på kilde-datasettet.
+              </Alert>
+            )}
+          </Tabs.Panel>
+        </Tabs>
+      </div>
+    </ReadMore>
+    </div>
+  )
+}
+
+export default MetabaseGrantSnippet

--- a/frontend/components/lib/copy.tsx
+++ b/frontend/components/lib/copy.tsx
@@ -1,42 +1,11 @@
-import { FilesIcon } from '@navikt/aksel-icons'
-import * as React from 'react'
-import { useState } from 'react'
-
-let timeout: NodeJS.Timeout | undefined = undefined
+import { CopyButton } from '@navikt/ds-react'
 
 type CopyProps = {
   text: string
 }
-const Copy = ({ text }: CopyProps) => {
-  const [copied, setCopied] = useState(false)
 
-  const copyToClipboard = (
-    e: React.MouseEvent<SVGSVGElement, MouseEvent>,
-    id: string | undefined
-  ) => {
-    id && navigator.clipboard.writeText(id)
-    setCopied(true)
-    if (timeout) {
-      clearTimeout(timeout)
-    }
-    timeout = setTimeout(() => {
-      setCopied(false)
-      timeout = undefined
-    }, 1500)
-  }
-  return (
-    <div className="inline relative">
-      <FilesIcon
-        className="text-ax-text-accent-subtle cursor-pointer hover:text-ax-text-accent hover:h-4"
-        onClick={(e) => copyToClipboard(e, text)}
-      />
-      {copied && (
-        <div className="absolute left-5 -top-2 px-2 p-1 rounded-sm bg-gray-100 border border-gray-300">
-          kopiert
-        </div>
-      )}
-    </div>
-  )
-}
+const Copy = ({ text }: CopyProps) => (
+  <CopyButton copyText={text} size="xsmall" />
+)
 
 export default Copy

--- a/frontend/lib/rest/generatedDto/index.ts
+++ b/frontend/lib/rest/generatedDto/index.ts
@@ -371,6 +371,7 @@ export const MetabaseDatabaseRestricted: MetabaseDatabaseType = "restricted";
 export interface MetabaseDataset {
   URL: string;
   Type: MetabaseDatabaseType;
+  saEmail?: string;
 }
 export interface DatasetWithAccess {
   id: string /* uuid */;

--- a/pkg/database/gensql/datasets_v2.sql.go
+++ b/pkg/database/gensql/datasets_v2.sql.go
@@ -63,7 +63,7 @@ func (q *Queries) GetAllDatasetsMinimal(ctx context.Context) ([]GetAllDatasetsMi
 
 const getDatasetComplete = `-- name: GetDatasetComplete :many
 SELECT
-  dp_group, ds_id, ds_name, ds_description, ds_created, ds_last_modified, ds_slug, pii, ds_keywords, ds_repo, ds_target_user, ds_anonymisation_description, bq_id, bq_created, bq_last_modified, bq_expires, bq_description, bq_missing_since, pii_tags, bq_project, bq_dataset, bq_table_name, bq_table_type, pseudo_columns, bq_schema, ds_dp_id, omb_database_id, rmb_database_id
+  dp_group, ds_id, ds_name, ds_description, ds_created, ds_last_modified, ds_slug, pii, ds_keywords, ds_repo, ds_target_user, ds_anonymisation_description, bq_id, bq_created, bq_last_modified, bq_expires, bq_description, bq_missing_since, pii_tags, bq_project, bq_dataset, bq_table_name, bq_table_type, pseudo_columns, bq_schema, ds_dp_id, omb_database_id, rmb_database_id, rmb_sa_email
 FROM
   dataset_view
 WHERE
@@ -108,6 +108,7 @@ func (q *Queries) GetDatasetComplete(ctx context.Context, id uuid.UUID) ([]Datas
 			&i.DsDpID,
 			&i.OmbDatabaseID,
 			&i.RmbDatabaseID,
+			&i.RmbSaEmail,
 		); err != nil {
 			return nil, err
 		}
@@ -124,7 +125,7 @@ func (q *Queries) GetDatasetComplete(ctx context.Context, id uuid.UUID) ([]Datas
 
 const getDatasetCompleteWithAccess = `-- name: GetDatasetCompleteWithAccess :many
 SELECT
-  dp_group, ds_id, ds_name, ds_description, ds_created, ds_last_modified, ds_slug, pii, ds_keywords, ds_repo, ds_target_user, ds_anonymisation_description, bq_id, bq_created, bq_last_modified, bq_expires, bq_description, bq_missing_since, pii_tags, bq_project, bq_dataset, bq_table_name, bq_table_type, pseudo_columns, bq_schema, ds_dp_id, omb_database_id, rmb_database_id, access_id, access_subject, access_owner, access_granter, access_expires, access_created, access_revoked, access_dataset_id, access_request_id, access_platform, access_request_owner, access_request_subject, access_request_last_modified, access_request_created, access_request_expires, access_request_status, access_request_closed, access_request_granter, access_request_reason, polly_id, polly_name, polly_url, polly_external_id
+  dp_group, ds_id, ds_name, ds_description, ds_created, ds_last_modified, ds_slug, pii, ds_keywords, ds_repo, ds_target_user, ds_anonymisation_description, bq_id, bq_created, bq_last_modified, bq_expires, bq_description, bq_missing_since, pii_tags, bq_project, bq_dataset, bq_table_name, bq_table_type, pseudo_columns, bq_schema, ds_dp_id, omb_database_id, rmb_database_id, rmb_sa_email, access_id, access_subject, access_owner, access_granter, access_expires, access_created, access_revoked, access_dataset_id, access_request_id, access_platform, access_request_owner, access_request_subject, access_request_last_modified, access_request_created, access_request_expires, access_request_status, access_request_closed, access_request_granter, access_request_reason, polly_id, polly_name, polly_url, polly_external_id
 FROM
   dataset_view dv
 LEFT JOIN dataset_access_view da ON da.access_dataset_id = dv.ds_id 
@@ -177,6 +178,7 @@ type GetDatasetCompleteWithAccessRow struct {
 	DsDpID                     uuid.UUID
 	OmbDatabaseID              sql.NullInt32
 	RmbDatabaseID              sql.NullInt32
+	RmbSaEmail                 sql.NullString
 	AccessID                   uuid.NullUUID
 	AccessSubject              sql.NullString
 	AccessOwner                sql.NullString
@@ -240,6 +242,7 @@ func (q *Queries) GetDatasetCompleteWithAccess(ctx context.Context, arg GetDatas
 			&i.DsDpID,
 			&i.OmbDatabaseID,
 			&i.RmbDatabaseID,
+			&i.RmbSaEmail,
 			&i.AccessID,
 			&i.AccessSubject,
 			&i.AccessOwner,

--- a/pkg/database/gensql/models.go
+++ b/pkg/database/gensql/models.go
@@ -351,6 +351,7 @@ type DatasetView struct {
 	DsDpID                     uuid.UUID
 	OmbDatabaseID              sql.NullInt32
 	RmbDatabaseID              sql.NullInt32
+	RmbSaEmail                 sql.NullString
 }
 
 type DatasourceBigquery struct {

--- a/pkg/database/migrations/0122_add_sa_email_to_dataset_view.sql
+++ b/pkg/database/migrations/0122_add_sa_email_to_dataset_view.sql
@@ -1,0 +1,116 @@
+-- +goose Up
+DROP VIEW IF EXISTS dataset_view CASCADE;
+CREATE VIEW dataset_view AS(
+    SELECT dp."group" AS dp_group,
+        ds.id AS ds_id,
+        ds.name AS ds_name,
+        ds.description AS ds_description,
+        ds.created AS ds_created,
+        ds.last_modified AS ds_last_modified,
+        ds.slug AS ds_slug,
+        ds.pii,
+        ds.keywords AS ds_keywords,
+        ds.repo AS ds_repo,
+        ds.target_user AS ds_target_user,
+        ds.anonymisation_description AS ds_anonymisation_description,
+        dsrc.id AS bq_id,
+        dsrc.created AS bq_created,
+        dsrc.last_modified AS bq_last_modified,
+        dsrc.expires AS bq_expires,
+        dsrc.description AS bq_description,
+        dsrc.missing_since AS bq_missing_since,
+        dsrc.pii_tags,
+        dsrc.project_id AS bq_project,
+        dsrc.dataset AS bq_dataset,
+        dsrc.table_name AS bq_table_name,
+        dsrc.table_type AS bq_table_type,
+        dsrc.pseudo_columns,
+        dsrc.schema AS bq_schema,
+        ds.dataproduct_id AS ds_dp_id,
+        omm.database_id AS omb_database_id,
+        rmm.database_id AS rmb_database_id,
+        rmm.sa_email AS rmb_sa_email
+    FROM datasets ds
+        LEFT JOIN (
+            SELECT
+                datasource_bigquery.dataset_id,
+                datasource_bigquery.project_id,
+                datasource_bigquery.dataset,
+                datasource_bigquery.table_name,
+                datasource_bigquery.schema,
+                datasource_bigquery.last_modified,
+                datasource_bigquery.created,
+                datasource_bigquery.expires,
+                datasource_bigquery.table_type,
+                datasource_bigquery.description,
+                datasource_bigquery.pii_tags,
+                datasource_bigquery.missing_since,
+                datasource_bigquery.id,
+                datasource_bigquery.is_reference,
+                datasource_bigquery.pseudo_columns,
+                datasource_bigquery.deleted
+            FROM datasource_bigquery
+            WHERE datasource_bigquery.is_reference = false
+        ) dsrc ON ds.id = dsrc.dataset_id
+        LEFT JOIN dataproducts dp ON ds.dataproduct_id = dp.id
+        LEFT JOIN restricted_metabase_metadata rmm ON ds.id = rmm.dataset_id
+        LEFT JOIN open_metabase_metadata omm ON ds.id = omm.dataset_id
+);
+
+-- +goose Down
+DROP VIEW IF EXISTS dataset_view CASCADE;
+CREATE VIEW dataset_view AS(
+    SELECT dp."group" AS dp_group,
+        ds.id AS ds_id,
+        ds.name AS ds_name,
+        ds.description AS ds_description,
+        ds.created AS ds_created,
+        ds.last_modified AS ds_last_modified,
+        ds.slug AS ds_slug,
+        ds.pii,
+        ds.keywords AS ds_keywords,
+        ds.repo AS ds_repo,
+        ds.target_user AS ds_target_user,
+        ds.anonymisation_description AS ds_anonymisation_description,
+        dsrc.id AS bq_id,
+        dsrc.created AS bq_created,
+        dsrc.last_modified AS bq_last_modified,
+        dsrc.expires AS bq_expires,
+        dsrc.description AS bq_description,
+        dsrc.missing_since AS bq_missing_since,
+        dsrc.pii_tags,
+        dsrc.project_id AS bq_project,
+        dsrc.dataset AS bq_dataset,
+        dsrc.table_name AS bq_table_name,
+        dsrc.table_type AS bq_table_type,
+        dsrc.pseudo_columns,
+        dsrc.schema AS bq_schema,
+        ds.dataproduct_id AS ds_dp_id,
+        omm.database_id AS omb_database_id,
+        rmm.database_id AS rmb_database_id
+    FROM datasets ds
+        LEFT JOIN (
+            SELECT
+                datasource_bigquery.dataset_id,
+                datasource_bigquery.project_id,
+                datasource_bigquery.dataset,
+                datasource_bigquery.table_name,
+                datasource_bigquery.schema,
+                datasource_bigquery.last_modified,
+                datasource_bigquery.created,
+                datasource_bigquery.expires,
+                datasource_bigquery.table_type,
+                datasource_bigquery.description,
+                datasource_bigquery.pii_tags,
+                datasource_bigquery.missing_since,
+                datasource_bigquery.id,
+                datasource_bigquery.is_reference,
+                datasource_bigquery.pseudo_columns,
+                datasource_bigquery.deleted
+            FROM datasource_bigquery
+            WHERE datasource_bigquery.is_reference = false
+        ) dsrc ON ds.id = dsrc.dataset_id
+        LEFT JOIN dataproducts dp ON ds.dataproduct_id = dp.id
+        LEFT JOIN restricted_metabase_metadata rmm ON ds.id = rmm.dataset_id
+        LEFT JOIN open_metabase_metadata omm ON ds.id = omm.dataset_id
+);

--- a/pkg/service/core/storage/postgres/postgres_dataproduct.go
+++ b/pkg/service/core/storage/postgres/postgres_dataproduct.go
@@ -25,9 +25,10 @@ const (
 var _ service.DataProductsStorage = &dataProductStorage{}
 
 type dataProductStorage struct {
-	databasesBaseURL string
-	db               *database.Repo
-	log              zerolog.Logger
+	databasesBaseURL     string
+	openMetabaseSAEmail  string
+	db                   *database.Repo
+	log                  zerolog.Logger
 }
 
 func (s *dataProductStorage) GetDataproductKeywords(ctx context.Context, dpid uuid.UUID) ([]string, error) {
@@ -575,16 +576,18 @@ func (s *dataProductStorage) GetDataproductOwner(ctx context.Context, dsID uuid.
 	return ownerGroup, nil
 }
 
-func (s *dataProductStorage) metabaseDatasetFromSQL(rmbDatasetID, ombDatasetID sql.NullInt32) *service.MetabaseDataset {
+func (s *dataProductStorage) metabaseDatasetFromSQL(rmbDatasetID, ombDatasetID sql.NullInt32, rmbSaEmail sql.NullString) *service.MetabaseDataset {
 	if rmbDatasetID.Valid {
 		return &service.MetabaseDataset{
-			URL:  fmt.Sprintf("%s/%v", s.databasesBaseURL, rmbDatasetID.Int32),
-			Type: service.MetabaseDatabaseRestricted,
+			URL:     fmt.Sprintf("%s/%v", s.databasesBaseURL, rmbDatasetID.Int32),
+			Type:    service.MetabaseDatabaseRestricted,
+			SAEmail: rmbSaEmail.String,
 		}
 	} else if ombDatasetID.Valid {
 		return &service.MetabaseDataset{
-			URL:  fmt.Sprintf("%s/%v", s.databasesBaseURL, ombDatasetID.Int32),
-			Type: service.MetabaseDatabaseOpen,
+			URL:     fmt.Sprintf("%s/%v", s.databasesBaseURL, ombDatasetID.Int32),
+			Type:    service.MetabaseDatabaseOpen,
+			SAEmail: s.openMetabaseSAEmail,
 		}
 	}
 
@@ -614,7 +617,7 @@ func (s *dataProductStorage) datasetFromSQL(dsrows []gensql.DatasetView) (*servi
 				Repo:                     nullStringToPtr(dsrow.DsRepo),
 				Datasource:               nil,
 				Pii:                      service.PiiLevel(dsrow.Pii),
-				MetabaseDataset:          s.metabaseDatasetFromSQL(dsrow.RmbDatabaseID, dsrow.OmbDatabaseID),
+				MetabaseDataset:          s.metabaseDatasetFromSQL(dsrow.RmbDatabaseID, dsrow.OmbDatabaseID, dsrow.RmbSaEmail),
 				TargetUser:               nullStringToPtr(dsrow.DsTargetUser),
 				AnonymisationDescription: nullStringToPtr(dsrow.DsAnonymisationDescription),
 			}
@@ -675,7 +678,7 @@ func (s *dataProductStorage) datasetWithAccessFromSQL(dsrows []gensql.GetDataset
 				Access:                   []*service.DatasetAccess{},
 				Datasource:               nil,
 				Pii:                      service.PiiLevel(dsrow.Pii),
-				MetabaseDataset:          s.metabaseDatasetFromSQL(dsrow.RmbDatabaseID, dsrow.OmbDatabaseID),
+				MetabaseDataset:          s.metabaseDatasetFromSQL(dsrow.RmbDatabaseID, dsrow.OmbDatabaseID, dsrow.RmbSaEmail),
 				TargetUser:               nullStringToPtr(dsrow.DsTargetUser),
 				AnonymisationDescription: nullStringToPtr(dsrow.DsAnonymisationDescription),
 			}
@@ -954,10 +957,21 @@ func dataproductFromSQL(dp *gensql.DataproductWithTeamkatalogenView) *service.Da
 	}
 }
 
-func NewDataProductStorage(databasesBaseURL string, db *database.Repo, log zerolog.Logger) *dataProductStorage {
+func NewDataProductStorage(databasesBaseURL string, cfg config.Config, db *database.Repo, log zerolog.Logger) *dataProductStorage {
+	openMetabaseSAEmail := ""
+	if cfg.Metabase.CredentialsPath != "" {
+		_, email, err := cfg.Metabase.LoadFromCredentialsPath()
+		if err != nil {
+			log.Warn().Err(err).Msg("loading metabase credentials for SA email")
+		} else {
+			openMetabaseSAEmail = email
+		}
+	}
+
 	return &dataProductStorage{
-		db:               db,
-		databasesBaseURL: databasesBaseURL,
-		log:              log,
+		db:                  db,
+		databasesBaseURL:    databasesBaseURL,
+		openMetabaseSAEmail: openMetabaseSAEmail,
+		log:                 log,
 	}
 }

--- a/pkg/service/core/storage/storage.go
+++ b/pkg/service/core/storage/storage.go
@@ -39,7 +39,7 @@ func NewStores(
 	return &Stores{
 		AccessStorage:             postgres.NewAccessStorage(db.Querier, database.WithTx[postgres.AccessQueries](db)),
 		BigQueryStorage:           postgres.NewBigQueryStorage(db),
-		DataProductsStorage:       postgres.NewDataProductStorage(cfg.Metabase.DatabasesBaseURL, db, log),
+		DataProductsStorage:       postgres.NewDataProductStorage(cfg.Metabase.DatabasesBaseURL, cfg, db, log),
 		InsightProductStorage:     postgres.NewInsightProductStorage(db),
 		JoinableViewsStorage:      postgres.NewJoinableViewStorage(db),
 		KeyWordStorage:            postgres.NewKeywordsStorage(db),

--- a/pkg/service/dataproducts.go
+++ b/pkg/service/dataproducts.go
@@ -78,8 +78,9 @@ const (
 )
 
 type MetabaseDataset struct {
-	URL  string
-	Type MetabaseDatabaseType
+	URL     string
+	Type    MetabaseDatabaseType
+	SAEmail string `json:"saEmail,omitempty"`
 }
 
 type DatasetWithAccess struct {


### PR DESCRIPTION
Adds a collapsible section on dataset pages that helps owners fix broken Metabase access after dbt/Terraform runs overwrite IAM grants.

Changes:
- Exposes the Metabase SA email in the dataset API (both open and restricted datasets)
- New "Metabase-tilgang i kode" component (visible to owners only) with copy-paste snippets for dbt grants config, Terraform IAM resources and BigQuery SQL GRANT statements
- Includes a warning for VIEW types about authorized views

Also replaces custom Copy with Aksel CopyButton