### PR TITLE
chore(ingress): Remove *.intern.nav.no ingresses and redirects

### DIFF
--- a/.github/workflows/build-and-deploy-frontend.yml
+++ b/.github/workflows/build-and-deploy-frontend.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Enable pnpm
         run: corepack enable pnpm
 
+      - name: Configure GitHub Packages auth
+        run: pnpm config set "//npm.pkg.github.com/:_authToken" "${{ secrets.READER_TOKEN }}"
+
       - name: Install dependencies
         working-directory: frontend
         run: pnpm install --frozen-lockfile

--- a/.nais/dev/metabase/gcp.yaml
+++ b/.nais/dev/metabase/gcp.yaml
@@ -55,12 +55,8 @@ spec:
       diskAutoresize: true
   image:  "{{ image }}"
   ingresses:
-    - https://metabase.intern.dev.nav.no
     - https://metabase.ansatt.dev.nav.no
     - https://metabase-inside.intern.dev.nav.no
-  redirects:
-    - from: https://metabase.intern.dev.nav.no
-      to: https://metabase.ansatt.dev.nav.no
   liveness:
     path: /api/health
   startup:

--- a/.nais/dev/nada-backend/nada-backend-config.yaml
+++ b/.nais/dev/nada-backend/nada-backend-config.yaml
@@ -21,7 +21,7 @@ data:
       api_url: http://metabase/api
       credentials_path: /var/run/secrets/metabase/meta_creds.json
       gcp_project: nada-dev-db2e
-      databases_base_url: https://metabase.intern.dev.nav.no/browse/databases
+      databases_base_url: https://metabase.ansatt.dev.nav.no/browse/databases
       mapping_deadline_sec: 600 # 10 minutes
       mapping_frequency_sec: 600 # 10 minutes
       kms:
@@ -29,7 +29,7 @@ data:
         location: europe-north1
         keyring: datamarkedsplassen
         key_name: sa-key-encrypter
-      host: https://metabase.intern.dev.nav.no
+      host: https://metabase.ansatt.dev.nav.no
     cross_team_pseudonymization:
       gcp_project_id: datamarkedsplassen-dev
       gcp_region: europe-north1

--- a/.nais/prod/metabase/gcp.yaml
+++ b/.nais/prod/metabase/gcp.yaml
@@ -49,12 +49,8 @@ spec:
       tier: db-custom-1-3840
   image: "{{ image }}"
   ingresses:
-    - https://metabase.intern.nav.no
     - https://metabase.ansatt.nav.no
     - https://metabase-inside.intern.nav.no
-  redirects:
-    - from: https://metabase.intern.nav.no
-      to: https://metabase.ansatt.nav.no
   liveness:
     path: /api/health
   startup:

--- a/.nais/prod/nada-backend/gcp.yaml
+++ b/.nais/prod/nada-backend/gcp.yaml
@@ -102,18 +102,4 @@ spec:
         - host: slack.com
         - host: hooks.slack.com
         - host: dvh.adeo.no
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    nginx.ingress.kubernetes.io/server-snippet: |
-      return 301 https://data.ansatt.nav.no$request_uri;
-  labels:
-    team: nada
-  name: dmp-redirect
-  namespace: nada
-spec:
-  ingressClassName: nais-ingress-external
-  rules:
-  - host: data.intern.nav.no
+

--- a/frontend/.nais/dev.yaml
+++ b/frontend/.nais/dev.yaml
@@ -14,11 +14,7 @@ spec:
   image: {{image}}
   port: 3000
   ingresses:
-    - https://data.intern.dev.nav.no
     - https://data.ansatt.dev.nav.no
-  redirects:
-    - from: https://data.intern.dev.nav.no
-      to: https://data.ansatt.dev.nav.no
   accessPolicy:
     outbound:
       rules:

--- a/frontend/.nais/prod.yaml
+++ b/frontend/.nais/prod.yaml
@@ -14,11 +14,7 @@ spec:
   image: {{image}}
   port: 3000
   ingresses:
-    - https://data.intern.nav.no
     - https://data.ansatt.nav.no
-  redirects:
-    - from: https://data.intern.nav.no
-      to: https://data.ansatt.nav.no
   accessPolicy:
     outbound:
       rules:

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -287,7 +287,7 @@ func NewMetabaseConfig() *MetabaseConfig {
 		Password:              "superdupersecret1",
 		SiteName:              "Nada Backend",
 		PremiumEmbeddingToken: os.Getenv("MB_PREMIUM_EMBEDDING_TOKEN"),
-		PublicHost:            "https://metabase.intern.nav.no",
+		PublicHost:            "https://metabase.ansatt.nav.no",
 	}
 }
 

--- a/test/integration/metabase/assets.go
+++ b/test/integration/metabase/assets.go
@@ -63,7 +63,7 @@ func (g *GCPHelper) Cleanup(ctx context.Context) {
 
 	err := g.cleanupAfterTestRun(ctx, g.bigqueryDataset)
 	if err != nil {
-		g.log.Fatal().Err(err).Msg("cleaning up after test run")
+		g.t.Errorf("cleaning up after test run: %v", err)
 	}
 
 	g.log.Info().Msg("GCP resources cleaned up successfully")

--- a/test/integration/metabase/metabase_test.go
+++ b/test/integration/metabase/metabase_test.go
@@ -760,7 +760,13 @@ func TestMetabaseOpenRestrictedDataset(t *testing.T) {
 
 		keys, err := saClient.ListServiceAccountKeys(ctx, fmt.Sprintf("projects/%s/serviceAccounts/%s", MetabaseProject, restrictedMeta.SAEmail))
 		require.NoError(t, err)
-		assert.Len(t, keys, 2) // will return 1 system managed key (always) in addition to the user managed key we created
+		userManagedKeys := 0
+		for _, k := range keys {
+			if k.KeyType != "SYSTEM_MANAGED" {
+				userManagedKeys++
+			}
+		}
+		assert.Equal(t, 1, userManagedKeys, "expected exactly 1 user-managed key; Google may return a varying number of system-managed keys")
 
 		bindings, err := crmClient.ListProjectIAMPolicyBindings(ctx, MetabaseProject, "serviceAccount:"+restrictedMeta.SAEmail)
 		require.NoError(t, err)
@@ -1046,7 +1052,13 @@ func TestMetabaseRestrictedDataset(t *testing.T) {
 
 		keys, err := saClient.ListServiceAccountKeys(ctx, fmt.Sprintf("projects/%s/serviceAccounts/%s", MetabaseProject, meta.SAEmail))
 		require.NoError(t, err)
-		assert.Len(t, keys, 2) // will return 1 system managed key (always) in addition to the user managed key we created
+		userManagedKeys := 0
+		for _, k := range keys {
+			if k.KeyType != "SYSTEM_MANAGED" {
+				userManagedKeys++
+			}
+		}
+		assert.Equal(t, 1, userManagedKeys, "expected exactly 1 user-managed key; Google may return a varying number of system-managed keys")
 
 		bindings, err := crmClient.ListProjectIAMPolicyBindings(ctx, MetabaseProject, "serviceAccount:"+meta.SAEmail)
 		require.NoError(t, err)


### PR DESCRIPTION
Removes metabase.intern.nav.no, data.intern.nav.no and their dev equivalents, in addition to redirects from *.intern.nav.no to *.ansatt.nav.no.

dmp-redirect needs to be deleted manually from the cluster afterwards.