### PR TITLE
feat(nc): switch NAIS Console auth from API key to workload binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ hack/.ipynb_checkpoints/
 /nada-backend
 onprem-firewall-map.yaml
 .agent
+.nais-proxy.pid

--- a/.nais/dev/nada-backend/nada-backend-config.yaml
+++ b/.nais/dev/nada-backend/nada-backend-config.yaml
@@ -69,7 +69,7 @@ data:
       impersonation_subject: johnny.horvi@nav.no
       credentials_file: /var/run/secrets/google-groups/sa.json
     nais_console:
-      api_key: # Loaded from env var NADA_NAIS_CONSOLE_API_KEY
+      token_path: # Loaded from env var NAIS_SERVICE_ACCOUNT_TOKEN_PATH
       api_url: https://console.nav.cloud.nais.io
     api:
       auth_token: # Loaded from env var NADA_API_AUTH_TOKEN

--- a/.nais/prod/nada-backend/nada-backend-config.yaml
+++ b/.nais/prod/nada-backend/nada-backend-config.yaml
@@ -69,7 +69,7 @@ data:
       impersonation_subject: johnny.horvi@nav.no
       credentials_file: /var/run/secrets/google-groups/sa.json
     nais_console:
-      api_key: # Loaded from env var NADA_NAIS_CONSOLE_API_KEY
+      token_path: # Loaded from env var NAIS_SERVICE_ACCOUNT_TOKEN_PATH
       api_url: https://console.nav.cloud.nais.io
     api:
       auth_token: # Loaded from env var NADA_API_AUTH_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ HUMANLOG_VERSION     := v0.7.8
 RIVERPRO			 ?= $(shell command -v riverpro || echo "$(GOBIN)/riverpro")
 RIVERPRO_VERSION     := v0.11.0
 
+NAIS_PROXY_PID_FILE  := .nais-proxy.pid
+
 $(SQLC):
 	$(call install-binary,sqlc,github.com/sqlc-dev/sqlc/cmd/sqlc@$(SQLC_VERSION))
 
@@ -220,16 +222,18 @@ setup-metabase:
 	./resources/scripts/configure_metabase.sh
 .PHONY: setup-metabase
 
-run-online: | $(HUMANLOG) onprem-map start-run-online-deps setup-metabase
+run-online: | $(HUMANLOG) onprem-map start-run-online-deps setup-metabase start-nais-proxy
 	@echo "Sourcing environment variables..."
-	set -a && source ./.env && set +a && \
+	trap '$(MAKE) -s stop-nais-proxy' EXIT; \
+		set -a && source ./.env && set +a && \
 		GOPROXY=$(GOPROXY) GONOSUMDB=$(GONOSUMDB) $(GO) run ./cmd/nada-backend --config ./config-local-online.yaml | $(HUMANLOG) --truncate=false
 .PHONY: run-online
 
-run-online-dbg: | start-run-online-deps setup-metabase
+run-online-dbg: | start-run-online-deps setup-metabase start-nais-proxy
 	@echo "Sourcing environment variables..."
 	GOPROXY=$(GOPROXY) GONOSUMDB=$(GONOSUMDB) $(GO) build -gcflags="all=-N -l" -o $(APP) ./cmd/nada-backend
-	set -a && source ./.env && set +a && \
+	trap '$(MAKE) -s stop-nais-proxy' EXIT; \
+		set -a && source ./.env && set +a && \
 		STORAGE_EMULATOR_HOST=http://localhost:8082/storage/v1/ ./$(APP) --config ./config-local-online.yaml
 
 start-run-online-deps: | docker-login pull-all
@@ -237,6 +241,26 @@ start-run-online-deps: | docker-login pull-all
 	@echo "Metabase version: $(METABASE_VERSION)"
 	DVH_VERSION=$(DVH_VERSION) MOCKS_VERSION=$(MOCKS_VERSION) METABASE_VERSION=$(METABASE_VERSION) $(DOCKER_COMPOSE) up -d $(COMPOS_DEPS_ONLINE_LOCAL)
 .PHONY: start-run-online-deps
+
+start-nais-proxy:
+	@echo "Starting nais api proxy on localhost:4242..."
+	@echo "dummy-local-token" > /tmp/nais-api-token
+	@if [ -f $(NAIS_PROXY_PID_FILE) ] && kill -0 $$(cat $(NAIS_PROXY_PID_FILE)) 2>/dev/null; then \
+		echo "nais api proxy already running (PID $$(cat $(NAIS_PROXY_PID_FILE)))"; \
+	else \
+		nais api proxy > /tmp/nais-proxy.log 2>&1 & echo $$! > $(NAIS_PROXY_PID_FILE); \
+		sleep 1; \
+		echo "nais api proxy started (PID $$(cat $(NAIS_PROXY_PID_FILE)))"; \
+	fi
+.PHONY: start-nais-proxy
+
+stop-nais-proxy:
+	@if [ -f $(NAIS_PROXY_PID_FILE) ]; then \
+		kill $$(cat $(NAIS_PROXY_PID_FILE)) 2>/dev/null || true; \
+		rm -f $(NAIS_PROXY_PID_FILE); \
+		echo "nais api proxy stopped"; \
+	fi
+.PHONY: stop-nais-proxy
 
 run: | start-run-deps setup-metabase
 	@echo "Sourcing environment variables..."
@@ -248,6 +272,7 @@ start-run-deps: | docker-login pull-all
 	@echo "Starting dependencies with docker compose... (fully local)"
 	@echo "Mocks version: $(MOCKS_VERSION)"
 	@echo "Metabase version: $(METABASE_VERSION)"
+	@echo "dummy-local-token" > /tmp/nais-api-token
 	set -a && source ./.env && set +a 
 	MOCKS_VERSION=$(MOCKS_VERSION) METABASE_VERSION=$(METABASE_VERSION) $(DOCKER_COMPOSE) up -d $(COMPOSE_DEPS_FULLY_LOCAL)
 .PHONY: start-run-deps

--- a/cmd/nada-backend/main.go
+++ b/cmd/nada-backend/main.go
@@ -171,7 +171,7 @@ func main() {
 	}
 
 	tkFetcher := tk.New(cfg.TeamsCatalogue.APIURL, httpClient)
-	ncFetcher := nc.New(cfg.NaisConsole.APIURL, cfg.NaisConsole.APIKey, cfg.NaisClusterName, httpClient)
+	ncFetcher := nc.New(cfg.NaisConsole.APIURL, cfg.NaisConsole.TokenPath, cfg.NaisClusterName, httpClient)
 
 	billingClient := cloudbilling.NewClient()
 

--- a/config-local-online.yaml
+++ b/config-local-online.yaml
@@ -71,8 +71,8 @@ gcp:
   big_query:
     team_project_pseudo_views_dataset_name: markedsplassen_pseudo_local
 nais_console:
-  api_key: # Loaded from env var NADA_NAIS_CONSOLE_API_KEY
-  api_url: https://console.nav.cloud.nais.io
+  token_path: /tmp/nais-api-token
+  api_url: http://localhost:4242
 api:
   auth_token: 1234
 workstation:

--- a/config-local.yaml
+++ b/config-local.yaml
@@ -66,7 +66,7 @@ gcp:
   big_query:
     team_project_pseudo_views_dataset_name: markedsplassen_pseudo_local
 nais_console:
-  api_key: verymuchfake
+  token_path: /tmp/nais-api-token
   api_url: http://localhost:8086
 api:
   auth_token: 1234

--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -303,13 +303,13 @@ func (a API) Validate() error {
 }
 
 type NaisConsole struct {
-	APIKey string `yaml:"api_key"`
-	APIURL string `yaml:"api_url"`
+	TokenPath string `yaml:"token_path"`
+	APIURL    string `yaml:"api_url"`
 }
 
 func (c NaisConsole) Validate() error {
 	return validation.ValidateStruct(&c,
-		validation.Field(&c.APIKey, validation.Required),
+		validation.Field(&c.TokenPath, validation.Required),
 		validation.Field(&c.APIURL, validation.Required, is.URL),
 	)
 }
@@ -662,6 +662,7 @@ func NewDefaultEnvBinder() *EnvBinder {
 		"NAIS_CLUSTER_NAME":                        "nais_cluster_name",
 		"NAIS_TOKEN_EXCHANGE_ENDPOINT":             "texas.endpoints.exchange",
 		"NAIS_TOKEN_INTROSPECTION_ENDPOINT":        "texas.endpoints.introspect",
+		"NAIS_SERVICE_ACCOUNT_TOKEN_PATH":          "nais_console.token_path",
 		"HOSTNAME":                                 "pod_name",
 	})
 }

--- a/pkg/config/v2/config_test.go
+++ b/pkg/config/v2/config_test.go
@@ -94,8 +94,8 @@ func newFakeConfig() config.Config {
 			CredentialsFile:      "/some/secret/path",
 		},
 		NaisConsole: config.NaisConsole{
-			APIKey: "fake_api_key",
-			APIURL: "http://localhost:8080/api",
+			TokenPath: "/fake/token/path",
+			APIURL:    "http://localhost:8080/api",
 		},
 		API: config.API{
 			AuthToken: "fake_token",

--- a/pkg/config/v2/testdata/config.yaml
+++ b/pkg/config/v2/testdata/config.yaml
@@ -71,7 +71,7 @@ google_groups:
     impersonation_subject: something@example.com
     credentials_file: /some/secret/path
 nais_console:
-    api_key: fake_api_key
+    token_path: /fake/token/path
     api_url: http://localhost:8080/api
 api:
     auth_token: fake_token

--- a/pkg/nc/nc.go
+++ b/pkg/nc/nc.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 )
 
 type Fetcher interface {
@@ -16,7 +18,7 @@ type Fetcher interface {
 type Client struct {
 	client          *http.Client
 	apiURL          string
-	apiKey          string
+	tokenPath       string
 	naisClusterName string
 }
 
@@ -164,16 +166,29 @@ func (c *Client) newRequestWithHeaders(ctx context.Context, method, path string,
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	if c.tokenPath != "" {
+		tokenBytes, err := os.ReadFile(c.tokenPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading service account token from %s: %w", c.tokenPath, err)
+		}
+
+		token := strings.TrimSpace(string(tokenBytes))
+		if token == "" {
+			return nil, fmt.Errorf("service account token file %s is empty", c.tokenPath)
+		}
+
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 
 	return req, nil
 }
 
-func New(apiURL, apiKey, naisClusterName string, client *http.Client) *Client {
+func New(apiURL, tokenPath, naisClusterName string, client *http.Client) *Client {
 	return &Client{
 		client:          client,
 		apiURL:          apiURL,
-		apiKey:          apiKey,
+		tokenPath:       tokenPath,
 		naisClusterName: naisClusterName,
 	}
 }

--- a/pkg/nc/nc_test.go
+++ b/pkg/nc/nc_test.go
@@ -5,11 +5,29 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/navikt/nada-backend/pkg/nc"
 	"github.com/stretchr/testify/assert"
 )
+
+const testToken = "super-secret"
+
+func writeTokenFile(t *testing.T) string {
+	t.Helper()
+
+	f, err := os.CreateTemp("", "nais-sa-token-*")
+	assert.NoError(t, err)
+
+	_, err = f.WriteString(testToken)
+	assert.NoError(t, err)
+	assert.NoError(t, f.Close())
+
+	t.Cleanup(func() { os.Remove(f.Name()) })
+
+	return f.Name()
+}
 
 func TestClient_GetTeamGoogleProjects(t *testing.T) {
 	testCases := []struct {
@@ -105,9 +123,11 @@ func TestClient_GetTeamGoogleProjects(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			tokenPath := writeTokenFile(t)
+
 			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "/graphql", r.URL.Path)
-				assert.Equal(t, "Bearer super-secret", r.Header.Get("Authorization"))
+				assert.Equal(t, "Bearer "+testToken, r.Header.Get("Authorization"))
 				assert.Equal(t, http.MethodPost, r.Method)
 
 				if tc.err != nil {
@@ -121,7 +141,7 @@ func TestClient_GetTeamGoogleProjects(t *testing.T) {
 				assert.NoError(t, err)
 			}))
 
-			client := nc.New(testServer.URL, "super-secret", tc.naisCluster, http.DefaultClient)
+			client := nc.New(testServer.URL, tokenPath, tc.naisCluster, http.DefaultClient)
 			got, err := client.GetTeamGoogleProjects(context.Background())
 			if tc.expectErr {
 				assert.Error(t, err)
@@ -131,4 +151,22 @@ func TestClient_GetTeamGoogleProjects(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_GetTeamGoogleProjects_NoToken(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(&nc.Response{
+			Data: nc.Data{Teams: nc.Teams{Nodes: []nc.Team{}, PageInfo: nc.PageInfo{HasNextPage: false}}},
+		})
+		assert.NoError(t, err)
+	}))
+
+	client := nc.New(testServer.URL, "", "env-1", http.DefaultClient)
+	got, err := client.GetTeamGoogleProjects(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, got)
 }


### PR DESCRIPTION
Replace the static API key with a service account workload binding. The NAIS platform injects a short-lived identity token at the path given by NAIS_SERVICE_ACCOUNT_TOKEN_PATH, which is re-read from disk on every request to handle in-place rotation.

For local development, nais api proxy is started automatically by make run-online and handles authentication using personal credentials. A dummy token file is written to /tmp/nais-api-token by the Makefile so config validation passes without manual steps.