### PR TITLE
chore(metabase): use nais injected postgres credentials directly

### DIFF
--- a/.nais/prod/metabase/gcp.yaml
+++ b/.nais/prod/metabase/gcp.yaml
@@ -29,6 +29,10 @@ spec:
     value: metabase
   - name: MB_DB_HOST
     value: "127.0.0.1"
+  - name: MB_DB_PASS
+    value: $(NAIS_DATABASE_METABASE_METABASE_PASSWORD)
+  - name: MB_DB_CONNECTION_URI
+    value: $(NAIS_DATABASE_METABASE_METABASE_JDBC_URL)
   {{#each envs}}
   - name: {{this.name}}
     value: "{{this.value}}"


### PR DESCRIPTION
There should be no need to copy the postgres secrets into a nais secret anymore. 