### PR TITLE
feat(knast): 4 timer som varighet for internettåpninger

### DIFF
--- a/frontend/components/knast/internetOpeningsForm.tsx
+++ b/frontend/components/knast/internetOpeningsForm.tsx
@@ -53,8 +53,8 @@ export const InternetOpeningsForm = () => {
     const saveUrlItem = async (urlListItem: any) => {
         setBackendError(undefined);
         const createdAt = new Date().toISOString();
-        const duration = urlListItem.duration === "01:00:00" ? 1 : urlListItem.duration === "12:00:00" ? 12 : 1;
-        const durationParam = urlListItem.duration === "01:00:00" ? "1hour" : urlListItem.duration === "12:00:00" ? "12hour" : "1hour";
+        const duration = urlListItem.duration === "01:00:00" ? 1 : urlListItem.duration === "04:00:00" ? 4 : urlListItem.duration === "12:00:00" ? 12 : 1;
+        const durationParam = urlListItem.duration === "01:00:00" ? "1hour" : urlListItem.duration === "04:00:00" ? "4hour" : urlListItem.duration === "12:00:00" ? "12hour" : "1hour";
         const expiresAt = addHours(createdAt, duration).toISOString();
         setUpdatingUrlIDs(new Set(updatingUrlIDs).add(urlListItem.id));
         try {
@@ -193,7 +193,7 @@ export const InternetOpeningsForm = () => {
                                             <h4 className="pt-2 pb-2">Tidsbegrensede åpninger</h4>
                                             <Button variant="tertiary" disabled={editingUrls?.some((it: any) => !it.id && it.isEditing)}
                                                 onClick={() => {
-                                                    setEditingUrls([...editingUrls, { id: undefined, url: "", duration: "1hour", isEditing: true, isValid: false, isEmpty: true, isChanged: true }]);
+                                                    setEditingUrls([...editingUrls, { id: undefined, url: "", duration: "01:00:00", isEditing: true, isValid: false, isEmpty: true, isChanged: true }]);
                                                 }} >
                                                 <div className="flex flex-row space-x-1 items-center"><p>Legg til</p><PlusCircleFillIcon /></div></Button>
 

--- a/frontend/components/knast/widgets/urlItem.tsx
+++ b/frontend/components/knast/widgets/urlItem.tsx
@@ -34,6 +34,8 @@ const backendDurationToHours = (duration: string) => {
     switch (duration) {
         case "01:00:00":
             return 1;
+        case "04:00:00":
+            return 4;
         case "12:00:00":
             return 12;
         default:
@@ -45,6 +47,7 @@ const backendDurationUnit = (duration: string) => {
     switch (duration) {
         case "01:00:00":
             return "time";
+        case "04:00:00":
         case "12:00:00":
             return "timer";
         default:
@@ -199,6 +202,7 @@ const UrlItemEditStyle = ({ item, onChangeUrl, onChangeDuration, onChangeDescrip
                                     </div>
                                     <Select size="small" value={item.duration || "01:00:00"} onChange={(e) => onChangeDuration?.(e.target.value)} label="" >
                                         <option value="01:00:00">1t</option>
+                                        <option value="04:00:00">4t</option>
                                         <option value="12:00:00">12t</option>
                                     </Select>
                                 </div>
@@ -321,7 +325,7 @@ const UrlItemPickStyle = ({ item, selectedItems, status, onToggle }: UrlItemProp
             <ExpendableTextDisplay text={item.url} />
             <p className="min-w-10" style={{
                 color: ColorAuxText
-            }}>{item.duration === "01:00:00" ? "1t" : item.duration === "12:00:00" ? "12t" : ""}</p>
+            }}>{item.duration === "01:00:00" ? "1t" : item.duration === "04:00:00" ? "4t" : item.duration === "12:00:00" ? "12t" : ""}</p>
             {item.selected !== selectedItems?.includes(item.id) && <Loader size="small" className="ml-2" />}
         </div>
     </div>

--- a/frontend/components/workstation/urlEditor/TimeRestrictedUrlEditor.tsx
+++ b/frontend/components/workstation/urlEditor/TimeRestrictedUrlEditor.tsx
@@ -19,25 +19,39 @@ import { nb } from 'date-fns/locale';
 import { useWorkstationURLListForIdent, useCreateWorkstationURLListItemForIdent, useUpdateWorkstationURLListItemForIdent, useDeleteWorkstationURLListItemForIdent, useActivateWorkstationURLListForIdent } from '../queries';
 import { WorkstationURLListItem } from '../../../lib/rest/generatedDto';
 
+export type TimeRestrictedUrlDuration = '1hour' | '4hours' | '12hours';
+
 export interface TimeRestrictedUrl {
     selected?: boolean;
     id: string;
     url: string;
     description: string;
-    duration: '12hours' | '1hour';
+    duration: TimeRestrictedUrlDuration;
     createdAt: Date;
     expiresAt: Date;
     isExpired: boolean;
     hasChanges?: boolean;
     editingDescription?: string;
     editingCustomDescription?: string;
-    editingDuration?: '12hours' | '1hour';
+    editingDuration?: TimeRestrictedUrlDuration;
 }
 
 const TIME_DURATIONS = {
     '1hour': { label: '1 time', value: '1hour', hours: 1 },
+    '4hours': { label: '4 timer', value: '4hours', hours: 4 },
     '12hours': { label: '12 timer', value: '12hours', hours: 12 }
 } as const;
+
+// Backend returns the duration as a Postgres interval, rendered as e.g.
+// '01:00:00', '04:00:00', '12:00:00', or as the '1hour'/'4hours'/'12hours'
+// strings the frontend sends when creating an item.
+const parseBackendDuration = (raw?: string): TimeRestrictedUrlDuration => {
+    if (!raw) return '1hour';
+    const normalized = raw.toLowerCase().replace(/\s+/g, '');
+    if (normalized.startsWith('12')) return '12hours';
+    if (normalized.startsWith('4') || normalized.startsWith('04')) return '4hours';
+    return '1hour';
+};
 
 // Predefined description options in Norwegian
 const PREDEFINED_DESCRIPTIONS = [
@@ -64,7 +78,7 @@ const TimeRestrictedUrlEditor: React.FC = () => {
     const [newUrl, setNewUrl] = useState('');
     const [newDescription, setNewDescription] = useState('');
     const [customDescription, setCustomDescription] = useState('');
-    const [selectedDuration, setSelectedDuration] = useState<'12hours' | '1hour'>('1hour');
+    const [selectedDuration, setSelectedDuration] = useState<TimeRestrictedUrlDuration>('1hour');
     const [error, setError] = useState<string | null>(null);
     const [success, setSuccess] = useState<string | null>(null);
     const [selectedUrls, setSelectedUrls] = useState<Set<string>>(new Set());
@@ -75,17 +89,7 @@ const TimeRestrictedUrlEditor: React.FC = () => {
         return items
             .filter((item): item is WorkstationURLListItem => item !== undefined)
             .map(item => {
-                // Handle different duration formats from backend
-                let duration: '12hours' | '1hour' = '1hour';
-                if (item.duration) {
-                    // Backend may return intervals like '1 hour', '12 hours', '01:00:00', '12:00:00', etc.
-                    const durationStr = item.duration.toLowerCase().replace(/\s+/g, '');
-                    if (durationStr.includes('12') || durationStr === '12:00:00') {
-                        duration = '12hours';
-                    } else if (durationStr.includes('1') || durationStr === '01:00:00') {
-                        duration = '1hour';
-                    }
-                }
+                const duration = parseBackendDuration(item.duration);
 
                 return {
                     id: item.id || Date.now().toString(),
@@ -148,9 +152,7 @@ const TimeRestrictedUrlEditor: React.FC = () => {
         try {
             const now = new Date();
             const duration = TIME_DURATIONS[selectedDuration];
-            const expiresAt = selectedDuration === '1hour'
-                ? addHours(now, duration.hours)
-                : addHours(now, duration.hours);
+            const expiresAt = addHours(now, duration.hours);
 
             // Use custom description if provided, otherwise use selected predefined description
             const finalDescription = customDescription.trim() || newDescription || undefined;
@@ -341,7 +343,7 @@ const TimeRestrictedUrlEditor: React.FC = () => {
         );
     };
 
-    const handleDurationChange = (id: string, value: '12hours' | '1hour') => {
+    const handleDurationChange = (id: string, value: TimeRestrictedUrlDuration) => {
         setTimeRestrictedUrls(prev =>
             prev.map(url => {
                 if (url.id === id) {
@@ -396,9 +398,7 @@ const TimeRestrictedUrlEditor: React.FC = () => {
             // Calculate new expiration time if duration changed
             let newExpiresAt = url.expiresAt;
             if (newDuration !== url.duration && !url.isExpired) {
-                newExpiresAt = newDuration === '1hour'
-                    ? addHours(now, durationInfo.hours)
-                    : addHours(now, durationInfo.hours);
+                newExpiresAt = addHours(now, durationInfo.hours);
             }
 
             const updatedItem: WorkstationURLListItem = {
@@ -445,7 +445,7 @@ const TimeRestrictedUrlEditor: React.FC = () => {
         );
     };
 
-    const handleEditingDurationChange = (id: string, value: '12hours' | '1hour') => {
+    const handleEditingDurationChange = (id: string, value: TimeRestrictedUrlDuration) => {
         setTimeRestrictedUrls(prev =>
             prev.map(url =>
                 url.id === id
@@ -566,7 +566,7 @@ const TimeRestrictedUrlEditor: React.FC = () => {
                                 <Select
                                     label="Varighet"
                                     value={selectedDuration}
-                                    onChange={(e) => setSelectedDuration(e.target.value as '12hours' | '1hour')}
+                                    onChange={(e) => setSelectedDuration(e.target.value as TimeRestrictedUrlDuration)}
                                     disabled={createUrlMutation.isPending || isLoadingData}
                                 >
                                     {Object.values(TIME_DURATIONS).map(duration => (
@@ -744,7 +744,7 @@ const TimeRestrictedUrlEditor: React.FC = () => {
                                                     <Select
                                                         label=""
                                                         value={url.editingDuration ?? url.duration}
-                                                        onChange={(e) => handleDurationChange(url.id, e.target.value as '12hours' | '1hour')}
+                                                        onChange={(e) => handleDurationChange(url.id, e.target.value as TimeRestrictedUrlDuration)}
                                                         disabled={createUrlMutation.isPending || isLoadingData}
                                                         className="w-full"
                                                         size="small"


### PR DESCRIPTION
## Hva

Legger til **4 timer** som valg for tidsbegrensede internettåpninger i Knast, tilsvarende navikt/knast-app#10.

## Hvorfor

Brukere har bare hatt 1t og 12t. Samme behov gjelder her siden Knast fortsatt støttes fra dette repoet.

## Endringer

Dette er en ren frontend-endring. Backend lagrer `duration` som en Postgres `INTERVAL`, og CHECK-constrainten i `0114_workstations_url_list.sql` er `duration >= '1 hour' AND duration <= '12 hours'` — den godtar altså `4 hours` allerede. Service-laget sender verdien rett videre uten validering.

**Nytt Knast-UI** (`components/knast/`)
- `widgets/urlItem.tsx`: `04:00:00` lagt til i varighetsvelgeren og i de to stedene som formaterer varighet for visning.
- `internetOpeningsForm.tsx`: mapper `04:00:00` → `4hour` mot API-et, og regner `expiresAt` med 4 timer.
- Samme fil: nye rader ble initialisert med `duration: "1hour"`, som ikke matcher noen `<option>`-verdi i velgeren. Endret til `01:00:00` slik at "1t" faktisk vises som valgt.

**Gammelt UI** (`components/workstation/urlEditor/TimeRestrictedUrlEditor.tsx`)
- `4hours` lagt til i `TIME_DURATIONS` og i unionstypen (nå navngitt `TimeRestrictedUrlDuration` i stedet for å gjentas åtte steder).
- Varighetsparsingen matchet på delstrenger (`durationStr.includes('12')`, så `includes('1')`). `04:00:00` traff ingen av dem og ville blitt vist som 1 time. Erstattet med `parseBackendDuration`, som matcher på prefiks og håndterer både intervallformatet fra backend og `1hour`/`4hours`/`12hours`-strengene frontend selv sender.
- Ryddet i to `a ? x : x`-uttrykk der begge grenene var identiske.

## Testing

- `tsc --noEmit`: ingen nye feil (de eksisterende gjelder CSS-/bilde-importer uten typedeklarasjoner).
- `eslint` på de tre endrede filene: 5 feil før og 5 feil etter, alle preeksisterende (`react-hooks/purity`, `react-hooks/set-state-in-effect`).